### PR TITLE
release: prepare KB 0.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ a knowledge base for coding agents.
 ## install
 
 ```sh
-bun add --global github:hraness/kb#v0.15.1
+bun add --global github:hraness/kb#v0.15.2
 ```
 
 ## about
@@ -169,7 +169,7 @@ Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
 Install hraness/kb and its bundled Agent Skills from
-https://github.com/hraness/kb at the immutable v0.15.1 tag. Follow the repository
+https://github.com/hraness/kb at the immutable v0.15.2 tag. Follow the repository
 README, install the `kb` CLI, copy or link the skills I need into this agent
 runner's configured skills directory, and verify the installation with
 `kb doctor` and `kb --help`. Do not initialize or modify a vault until I ask.
@@ -181,10 +181,10 @@ can inspect the tagged instructions before copying or linking the selected
 directory into its runner-specific discovery path. Installation leaves the
 skills inert and does not edit project or user configuration.
 
-Install the CLI from the immutable `v0.15.1` tag:
+Install the CLI from the immutable `v0.15.2` tag:
 
 ```sh
-bun add --global github:hraness/kb#v0.15.1
+bun add --global github:hraness/kb#v0.15.2
 kb --help
 ```
 
@@ -193,7 +193,7 @@ For programmatic use, declare the same pinned source in a project:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "github:hraness/kb#v0.15.1"
+    "@hraness/kb": "github:hraness/kb#v0.15.2"
   }
 }
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@hraness/kb",
       "dependencies": {
-        "@steipete/sweet-cookie": "git+https://github.com/hraness/sweet-cookie.git#112dce1a3c3dd165310616ca63dd2f6cc652b212",
+        "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
         "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
         "agent-browser": "0.32.3",
         "defuddle": "0.19.1",
@@ -88,7 +88,7 @@
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
-    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@github:hraness/sweet-cookie#112dce1", { "bin": { "sweet-cookie": "packages/core/dist/cli.js" } }, "hraness-sweet-cookie-112dce1", "sha512-g7DkRQ0VzpFxONWGJnha/8d2AcAibkToTpg19XraG9ikK+ZvVwe58y2ClAy+O9nfjzE9l74iuujtZAl174gYhw=="],
+    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@github:hraness/sweet-cookie#04ddf06", { "bin": { "sweet-cookie": "packages/core/dist/cli.js" } }, "hraness-sweet-cookie-04ddf06", "sha512-SxVC8mp7OiWY4RHtBPlDl51xpRDTh8lNctnLdUGdos62oflrrroC3qQZ/YMdR2Vd62wKUBmnErBlrLumTuj2cw=="],
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 

--- a/dist/capture.js
+++ b/dist/capture.js
@@ -5,14 +5,14 @@ import {
   captureSummary,
   main,
   runCapture
-} from "./index-2cw7jeq4.js";
+} from "./index-tw4g2vk4.js";
 import"./index-tp2p17gt.js";
 import"./index-f984hw45.js";
 import {
   adapterCapabilities,
   inspectClipEnvironment,
   renderDoctorReport
-} from "./index-h2a142gc.js";
+} from "./index-xwsdr1v8.js";
 import"./index-bt118a7q.js";
 import"./index-hgve9rh2.js";
 import"./index-w2zc0vwa.js";

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -94,10 +94,10 @@ import {
 } from "./index-4962kvds.js";
 import {
   main
-} from "./index-2cw7jeq4.js";
+} from "./index-tw4g2vk4.js";
 import"./index-tp2p17gt.js";
 import"./index-f984hw45.js";
-import"./index-h2a142gc.js";
+import"./index-xwsdr1v8.js";
 import {
   findKbPackageRoot
 } from "./index-bt118a7q.js";

--- a/dist/clip/cli.js
+++ b/dist/clip/cli.js
@@ -5,10 +5,10 @@ import {
   captureSucceeded,
   captureSummary,
   main
-} from "../index-2cw7jeq4.js";
+} from "../index-tw4g2vk4.js";
 import"../index-tp2p17gt.js";
 import"../index-f984hw45.js";
-import"../index-h2a142gc.js";
+import"../index-xwsdr1v8.js";
 import"../index-bt118a7q.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";

--- a/dist/clip/doctor.js
+++ b/dist/clip/doctor.js
@@ -9,7 +9,7 @@ import {
   renderAdapterCapabilities,
   renderDoctorReport,
   runDiagnosticCommand
-} from "../index-h2a142gc.js";
+} from "../index-xwsdr1v8.js";
 import"../index-bt118a7q.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";

--- a/dist/index-tw4g2vk4.js
+++ b/dist/index-tw4g2vk4.js
@@ -18,7 +18,7 @@ import {
   inspectClipEnvironment,
   renderAdapterCapabilities,
   renderDoctorReport
-} from "./index-h2a142gc.js";
+} from "./index-xwsdr1v8.js";
 import {
   acquireBrowser,
   acquireCookieHttp,

--- a/dist/index-xwsdr1v8.js
+++ b/dist/index-xwsdr1v8.js
@@ -23,7 +23,7 @@ var homebrewSqliteLibraryPaths = [
 var dependencyVersions = {
   defuddle: "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.0",
+  "@steipete/sweet-cookie": "0.4.2",
   "@tobilu/qmd": expectedQmdVersion
 };
 var dependencyNames = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "type": "module",
@@ -341,7 +341,7 @@
     "prepack": "bun run check"
   },
   "dependencies": {
-    "@steipete/sweet-cookie": "git+https://github.com/hraness/sweet-cookie.git#112dce1a3c3dd165310616ca63dd2f6cc652b212",
+    "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
     "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
     "agent-browser": "0.32.3",
     "defuddle": "0.19.1",

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,14 +8,14 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.15.1"
+      "version": "0.15.2"
     }
   ],
   "dependencies": [
     {
       "from": "@hraness/kb",
       "scope": "runtime",
-      "specifier": "git+https://github.com/hraness/sweet-cookie.git#112dce1a3c3dd165310616ca63dd2f6cc652b212",
+      "specifier": "github:hraness/sweet-cookie#v0.4.2",
       "to": "@steipete/sweet-cookie",
       "sourceRepository": "hraness/sweet-cookie"
     },

--- a/scripts/check-portfolio-inventory.test.ts
+++ b/scripts/check-portfolio-inventory.test.ts
@@ -20,11 +20,24 @@ function manifest(dependencies: Record<string, string>): Record<string, unknown>
 }
 
 describe("portfolio inventory dependencies", () => {
-  test("derives Hraness ownership only from exact immutable GitHub specifiers", () => {
+  test("derives Hraness ownership only from exact immutable GitHub commits or stable tags", () => {
     expect(hranessSourceRepository(
       `git+https://github.com/hraness/qmd.git#${commit}`,
     )).toBe("hraness/qmd");
-    expect(hranessSourceRepository("github:hraness/qmd#main")).toBeUndefined();
+    expect(hranessSourceRepository(
+      "github:hraness/sweet-cookie#v0.4.2",
+    )).toBe("hraness/sweet-cookie");
+    for (const invalidSpecifier of [
+      "github:hraness/qmd#main",
+      "github:hraness/qmd#v2.5",
+      "github:hraness/qmd#v2.5.3-rc.1",
+      "github:hraness/qmd#v02.5.3",
+      "github:hraness/qmd#2.5.3",
+      "github:hraness/qmd.git#v2.5.3",
+      "github:other/qmd#v2.5.3",
+    ]) {
+      expect(hranessSourceRepository(invalidSpecifier)).toBeUndefined();
+    }
     expect(hranessSourceRepository(
       "git+https://github.com/other/qmd.git#0123456789abcdef0123456789abcdef01234567",
     )).toBeUndefined();
@@ -38,7 +51,7 @@ describe("portfolio inventory dependencies", () => {
       "ordinary-package": "1.0.0",
       "@tobilu/qmd": `git+https://github.com/hraness/qmd.git#${commit}`,
       "@hraness/ui": "^0.4.0",
-      "@steipete/sweet-cookie": `git+https://github.com/hraness/sweet-cookie.git#${commit}`,
+      "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
     }));
 
     expect(inventory.dependencies).toEqual([
@@ -51,7 +64,7 @@ describe("portfolio inventory dependencies", () => {
       {
         from: "@hraness/example",
         scope: "runtime",
-        specifier: `git+https://github.com/hraness/sweet-cookie.git#${commit}`,
+        specifier: "github:hraness/sweet-cookie#v0.4.2",
         to: "@steipete/sweet-cookie",
         sourceRepository: "hraness/sweet-cookie",
       },

--- a/scripts/check-portfolio-inventory.ts
+++ b/scripts/check-portfolio-inventory.ts
@@ -41,8 +41,11 @@ function asciiCompare(left: string, right: string): number {
 }
 
 export function hranessSourceRepository(specifier: string): string | undefined {
-  const match = /^git\+https:\/\/github\.com\/(hraness\/[A-Za-z0-9._-]+)\.git#[0-9a-f]{40}$/u.exec(specifier);
-  return match?.[1];
+  const commitMatch = /^git\+https:\/\/github\.com\/(hraness\/[A-Za-z0-9._-]+)\.git#[0-9a-f]{40}$/u.exec(specifier);
+  if (commitMatch?.[1] !== undefined) return commitMatch[1];
+  const stableTagMatch = /^github:(hraness\/[A-Za-z0-9._-]+)#v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$/u.exec(specifier);
+  const sourceRepository = stableTagMatch?.[1];
+  return sourceRepository?.endsWith(".git") === true ? undefined : sourceRepository;
 }
 
 export function canonicalPortfolioInventory(value: unknown): Record<string, unknown> {

--- a/src/clip/doctor.test.ts
+++ b/src/clip/doctor.test.ts
@@ -35,7 +35,7 @@ describe("clip doctor", () => {
         dependencies: {
           defuddle: "^0.19.1",
           "agent-browser": "0.32.3",
-          "@steipete/sweet-cookie": "github:hraness/sweet-cookie#0123456789012345678901234567890123456789",
+          "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
           "@tobilu/qmd": "2.5.3",
         },
       })],
@@ -43,7 +43,7 @@ describe("clip doctor", () => {
       [join(consumerRoot, "node_modules", "agent-browser", "package.json"), packageManifest("agent-browser", "0.32.3")],
       [
         join(consumerRoot, "node_modules", "@steipete", "sweet-cookie", "package.json"),
-        packageManifest("@steipete/sweet-cookie", "0.4.0"),
+        packageManifest("@steipete/sweet-cookie", "0.4.2"),
       ],
       [join(qmdRoot, "package.json"), packageManifest("@tobilu/qmd", "2.5.3")],
       [join(qmdRoot, "node_modules", "sqlite-vec", "package.json"), packageManifest("sqlite-vec", "0.1.9")],
@@ -136,6 +136,16 @@ describe("clip doctor", () => {
       installedVersion: "2.5.3",
       status: "ready",
     });
+    expect(report.dependencies.find(({ name }) => name === "@steipete/sweet-cookie")).toEqual({
+      name: "@steipete/sweet-cookie",
+      expectedVersion: "0.4.2",
+      declaredVersion: "github:hraness/sweet-cookie#v0.4.2",
+      installedVersion: "0.4.2",
+      status: "ready",
+    });
+    expect(renderDoctorReport(report)).toContain(
+      "@steipete/sweet-cookie: ready (declared github:hraness/sweet-cookie#v0.4.2; installed 0.4.2; expected 0.4.2)",
+    );
     expect(report.search.keywordOnly).toEqual({ status: "ready", modelRequired: false });
     expect(report.search.semanticPrerequisites).toMatchObject({
       status: "ready",

--- a/src/clip/doctor.ts
+++ b/src/clip/doctor.ts
@@ -142,7 +142,7 @@ type JsonRecord = Readonly<Record<string, unknown>>;
 const dependencyVersions = {
   "defuddle": "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.0",
+  "@steipete/sweet-cookie": "0.4.2",
   "@tobilu/qmd": expectedQmdVersion,
 } as const satisfies Readonly<Record<DependencyReport["name"], string>>;
 const dependencyNames: readonly DependencyReport["name"][] = [


### PR DESCRIPTION
## Summary

- prepare @hraness/kb 0.15.2 across package, README, portfolio inventory, and committed dist
- consume Sweet Cookie from the exact immutable github:hraness/sweet-cookie#v0.4.2 tag and accept only exact stable Hraness GitHub tags in inventory ownership
- update doctor expected-version reporting with an explicit 0.4.2 regression while preserving v0.15.1 self-bootstrap pins

## Verification

- Bun 1.3.14 frozen install and byte-stable lockfile
- focused inventory and doctor tests: 12 passed
- bun run check: 1078 passed, including package, Node 24, CLI, type, and Rust helper smokes
- bun pm pack --dry-run: 188 files