### PR TITLE
release: prepare KB 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a knowledge base for coding agents.
 ## install
 
 ```sh
-bun add --global github:hraness/kb#v0.15.2
+bun add --global github:hraness/kb#v0.16.0
 ```
 
 ## about
@@ -172,7 +172,7 @@ Copy this prompt into Codex, Claude Code, or another coding agent:
 ```text
 Install the `kb` Agent Skill from hraness/kb with the standard skills CLI. Use
 the skill's runtime instructions to install the `kb` CLI from the immutable
-v0.15.2 release only when the command is missing. Verify it with `kb doctor`
+v0.16.0 release only when the command is missing. Verify it with `kb doctor`
 and `kb --help`, but do not initialize or modify a vault until I ask.
 ```
 
@@ -187,18 +187,17 @@ Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `v0.15.2` tag.
+CLI from the immutable `v0.16.0` tag.
 
-The public skills CLI reads `skills/kb/` from the repository. Packages built
-from this source also include the same tree under
-`node_modules/@hraness/kb/skills/kb/`. The current `v0.15.2` runtime tag
-predates this consolidated skill, so use the skills CLI for runner discovery
-until a later tagged package includes it.
+The public skills CLI reads `skills/kb/` from the repository. The immutable
+`v0.16.0` package includes the same tree under
+`node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
+installed skill is byte-identical to the repository source.
 
-Install the CLI from the immutable `v0.15.2` tag:
+Install the CLI from the immutable `v0.16.0` tag:
 
 ```sh
-bun add --global github:hraness/kb#v0.15.2
+bun add --global github:hraness/kb#v0.16.0
 kb --help
 ```
 
@@ -207,7 +206,7 @@ For programmatic use, declare the same pinned source in a project:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "github:hraness/kb#v0.15.2"
+    "@hraness/kb": "github:hraness/kb#v0.16.0"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "type": "module",

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.15.2"
+      "version": "0.16.0"
     }
   ],
   "dependencies": [

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -31,7 +31,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global github:hraness/kb#v0.15.2
+  bun add --global github:hraness/kb#v0.16.0
 }
 kb --help
 ```


### PR DESCRIPTION
## Summary

- publish the consolidated public KB Agent Skill in the tagged package
- update immutable install pins to v0.16.0
- align package and portfolio inventory versions

## Verification

- full repository check
- package smoke test under Node 24
- portfolio inventory and installed-command documentation checks
- official skills CLI discovery of exactly one kb skill
- independent review with no findings