### PR TITLE
release: improve KB package discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 
 [![skills.sh](https://skills.sh/b/hraness/kb)](https://skills.sh/hraness/kb)
 
-a knowledge base for coding agents.
+a knowledge base for coding agents, built from Markdown, backlinks, semantic
+search, and Git context.
 
 ## install
 
 ```sh
-bun add --global @hraness/kb@0.17.1
+bun add --global @hraness/kb@0.17.2
 ```
 
 ## about
@@ -44,7 +45,9 @@ kb history search packages/parser --root . --repo .. --json
 
 ## links
 
-[github](https://github.com/hraness/kb)
+[npm](https://www.npmjs.com/package/@hraness/kb) ·
+[github](https://github.com/hraness/kb) ·
+[overview](https://hraness.com/kb)
 <!-- hraness:kb-landing:end -->
 
 ## A knowledge base for your coding agents
@@ -165,6 +168,12 @@ Start with a short inherited `AGENTS.md` path for rules whose omission would mak
 
 Treat the knowledge base as repository-adjacent durable memory. Authored Markdown and Git are the record; catalogs, indexes, embeddings, and graph views are replaceable ways to find and inspect it. Checks can validate structure, captures can preserve a selected surface, and similarity can suggest candidates. None of those mechanisms proves that a source is trustworthy or an explanation is still true. People and agents must revise the knowledge as the repository changes.
 
+## Upgrade to v0.17.2
+
+Version 0.17.2 improves package discovery through focused npm keywords, a more
+specific README opening, and direct links between npm, GitHub, and the project
+overview. Runtime APIs and package behavior are unchanged.
+
 ## Upgrade to v0.17.1
 
 Version 0.17.1 adds the public `@hraness/kb` npm installation path without
@@ -208,7 +217,7 @@ Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
 Install the `kb` Agent Skill from hraness/kb with the standard skills CLI. Use
-the skill's runtime instructions to install the exact `@hraness/kb@0.17.1`
+the skill's runtime instructions to install the exact `@hraness/kb@0.17.2`
 registry release only when the command is missing. Verify it with `kb doctor`
 and `kb --help`, but do not initialize or modify a vault until I ask.
 ```
@@ -224,17 +233,17 @@ Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.17.1` npm version.
+CLI from the immutable `@hraness/kb@0.17.2` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.17.1` npm package includes the same tree under
+`0.17.2` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.17.1
+bun add --global @hraness/kb@0.17.2
 kb --help
 kb-evaluation-builder --help
 ```
@@ -242,7 +251,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.17.1
+npm install --global --ignore-scripts @hraness/kb@0.17.2
 kb --help
 ```
 
@@ -255,7 +264,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.17.1
+bun add --exact @hraness/kb@0.17.2
 ```
 
 The resulting dependency should remain exact:
@@ -263,12 +272,12 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.17.1"
+    "@hraness/kb": "0.17.2"
   }
 }
 ```
 
-Version 0.17.1 intentionally retains two public GitHub dependencies:
+Version 0.17.2 retains two public GitHub dependencies:
 `@steipete/sweet-cookie` at Hraness release `v0.4.2` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
 `aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior. A

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -127,7 +127,7 @@ keep the tag and npm version immutable. After the recovery workflow is on
 current `main`, dispatch it with the existing tag:
 
 ```sh
-gh workflow run release.yml --ref main -f tag=v0.17.1
+gh workflow run release.yml --ref main -f tag=v0.17.2
 ```
 
 The recovery path accepts only the newest stable repository tag. It freshly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {
@@ -72,15 +72,16 @@
   },
   "keywords": [
     "knowledge-base",
+    "coding-agents",
+    "agent-memory",
+    "repository-context",
     "markdown",
     "obsidian",
+    "agents-md",
     "web-clipper",
     "backlinks",
     "knowledge-graph",
     "semantic-search",
-    "agent-memory",
-    "agents-md",
-    "context-engineering",
     "local-first"
   ],
   "exports": {

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.17.1"
+      "version": "0.17.2"
     }
   ],
   "dependencies": [

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -16,6 +16,7 @@ const stageWorkflowUrl = new URL("../.github/workflows/npm-stage.yml", import.me
 const releaseWorkflowUrl = new URL("../.github/workflows/release.yml", import.meta.url);
 const ciWorkflowUrl = new URL("../.github/workflows/ci.yml", import.meta.url);
 const manifestUrl = new URL("../package.json", import.meta.url);
+const readmeUrl = new URL("../README.md", import.meta.url);
 const packageSmokeUrl = new URL("./package-smoke.ts", import.meta.url);
 const packagePreparationUrl = new URL("./prepare-npm-package.ts", import.meta.url);
 const packageArtifactUrl = new URL("./package-artifact.ts", import.meta.url);
@@ -108,6 +109,43 @@ function writeHeaderChecksum(tar: Buffer, offset: number): void {
 }
 
 describe("npm release workflows", () => {
+  test("keeps npm discoverability metadata focused and aligned with the README", async () => {
+    const [manifestSource, readme] = await Promise.all([
+      readFile(manifestUrl, "utf8"),
+      readFile(readmeUrl, "utf8"),
+    ]);
+    const manifest = JSON.parse(manifestSource) as {
+      readonly description?: unknown;
+      readonly keywords?: unknown;
+      readonly version?: unknown;
+    };
+    expect(manifest).toEqual(expect.objectContaining({
+      version: "0.17.2",
+      description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
+      keywords: [
+        "knowledge-base",
+        "coding-agents",
+        "agent-memory",
+        "repository-context",
+        "markdown",
+        "obsidian",
+        "agents-md",
+        "web-clipper",
+        "backlinks",
+        "knowledge-graph",
+        "semantic-search",
+        "local-first",
+      ],
+    }));
+    const opening = readme.slice(0, 1_500).replace(/\s+/gu, " ").toLowerCase();
+    expect(opening).toContain(String(manifest.description).toLowerCase());
+    for (const link of [
+      "[npm](https://www.npmjs.com/package/@hraness/kb)",
+      "[github](https://github.com/hraness/kb)",
+      "[overview](https://hraness.com/kb)",
+    ]) expect(readme).toContain(link);
+  });
+
   test("keeps the exact terminal OIDC stage independent from repository code", async () => {
     const workflow = await readFile(stageWorkflowUrl, "utf8");
     const selectStart = workflow.indexOf("\n  select:\n");
@@ -367,7 +405,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(200);
-      expect(verified.unpackedBytes).toBe(4_860_250);
+      expect(verified.unpackedBytes).toBe(4_860_653);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/scripts/npm-stage-selection.test.ts
+++ b/scripts/npm-stage-selection.test.ts
@@ -14,11 +14,11 @@ function manifest(version: unknown, name: unknown = "@hraness/kb"): string {
 describe("npm stage selection", () => {
   test("selects a strictly increasing stable version from a push", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.18.0"),
+      currentManifest: manifest("0.17.2"),
       eventName: "push",
       previousManifest: manifest("0.17.1"),
     })).toEqual({
-      currentVersion: "0.18.0",
+      currentVersion: "0.17.2",
       previousVersion: "0.17.1",
       reason: "stable-version-increase",
       shouldStage: true,
@@ -27,12 +27,12 @@ describe("npm stage selection", () => {
 
   test("makes an unrelated package.json edit a successful no-op", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.17.1"),
+      currentManifest: manifest("0.17.2"),
       eventName: "push",
-      previousManifest: manifest("0.17.1"),
+      previousManifest: manifest("0.17.2"),
     })).toEqual({
-      currentVersion: "0.17.1",
-      previousVersion: "0.17.1",
+      currentVersion: "0.17.2",
+      previousVersion: "0.17.2",
       reason: "version-unchanged",
       shouldStage: false,
     });
@@ -40,10 +40,10 @@ describe("npm stage selection", () => {
 
   test("retains a manual current-version recovery request", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.17.1"),
+      currentManifest: manifest("0.17.2"),
       eventName: "workflow_dispatch",
     })).toEqual({
-      currentVersion: "0.17.1",
+      currentVersion: "0.17.2",
       reason: "manual-recovery",
       shouldStage: true,
     });
@@ -53,17 +53,17 @@ describe("npm stage selection", () => {
     expect(() => selectNpmStage({
       currentManifest: manifest("0.17.0"),
       eventName: "push",
-      previousManifest: manifest("0.17.1"),
+      previousManifest: manifest("0.17.2"),
     })).toThrow("Package version must increase");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0-beta.1"),
       eventName: "push",
-      previousManifest: manifest("0.17.1"),
+      previousManifest: manifest("0.17.2"),
     })).toThrow("stable semantic version");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0", "@hraness/not-kb"),
       eventName: "push",
-      previousManifest: manifest("0.17.1"),
+      previousManifest: manifest("0.17.2"),
     })).toThrow("must identify @hraness/kb");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0"),
@@ -113,7 +113,7 @@ describe("npm stage selection", () => {
       const previousManifest = join(work, "previous-package.json");
       const githubOutput = join(work, "github-output.txt");
       await Promise.all([
-        writeFile(currentManifest, manifest("0.18.0")),
+        writeFile(currentManifest, manifest("0.17.2")),
         writeFile(previousManifest, manifest("0.17.1")),
       ]);
       const child = Bun.spawn([
@@ -136,9 +136,9 @@ describe("npm stage selection", () => {
       ]);
       expect(error).toBe("");
       expect(exitCode).toBe(0);
-      expect(output).toContain("Stage @hraness/kb@0.18.0: stable-version-increase");
+      expect(output).toContain("Stage @hraness/kb@0.17.2: stable-version-increase");
       expect(await readFile(githubOutput, "utf8")).toBe(
-        "current_version=0.18.0\n"
+        "current_version=0.17.2\n"
         + "reason=stable-version-increase\n"
         + "should_stage=true\n"
         + "previous_version=0.17.1\n",

--- a/scripts/package-smoke.ts
+++ b/scripts/package-smoke.ts
@@ -407,7 +407,9 @@ async function verifyInstalledPackagePolicy(consumer: string): Promise<Readonly<
   const installedPackage = join(consumer, "node_modules", "@hraness", "kb");
   type PackageIdentity = {
     readonly contentPolicy?: { readonly class?: unknown };
+    readonly description?: unknown;
     readonly engines?: { readonly bun?: unknown };
+    readonly keywords?: unknown;
     readonly name?: unknown;
     readonly publishConfig?: {
       readonly access?: unknown;
@@ -426,8 +428,12 @@ async function verifyInstalledPackagePolicy(consumer: string): Promise<Readonly<
   if (
     sourceManifest.name !== packageName
     || typeof sourceManifest.version !== "string"
+    || typeof sourceManifest.description !== "string"
+    || !Array.isArray(sourceManifest.keywords)
     || manifest.name !== sourceManifest.name
     || manifest.version !== sourceManifest.version
+    || manifest.description !== sourceManifest.description
+    || JSON.stringify(manifest.keywords) !== JSON.stringify(sourceManifest.keywords)
   ) {
     throw new Error("installed package identity does not match the source package");
   }

--- a/scripts/prepare-npm-package.ts
+++ b/scripts/prepare-npm-package.ts
@@ -24,6 +24,25 @@ function stringField(value: Record<string, unknown>, key: string, label: string)
   return field;
 }
 
+function keywordField(value: Record<string, unknown>, key: string, label: string): void {
+  const field = value[key];
+  if (!Array.isArray(field) || field.length === 0 || field.length > 16) {
+    throw new Error(`${label}.${key} must contain 1-16 focused keywords`);
+  }
+  const keywords = field.map((keyword, index) => {
+    if (
+      typeof keyword !== "string"
+      || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(keyword)
+    ) {
+      throw new Error(`${label}.${key}[${String(index)}] must be a lowercase keyword`);
+    }
+    return keyword;
+  });
+  if (new Set(keywords).size !== keywords.length) {
+    throw new Error(`${label}.${key} cannot contain duplicates`);
+  }
+}
+
 function integerField(value: Record<string, unknown>, key: string, label: string): number {
   const field = value[key];
   if (!Number.isSafeInteger(field) || (field as number) < 0) {
@@ -65,6 +84,7 @@ function verifyPublicManifest(manifest: Record<string, unknown>): string {
     throw new Error(`package.json version is not a stable semantic version: ${manifestVersion}`);
   }
   stringField(manifest, "description", "package.json");
+  keywordField(manifest, "keywords", "package.json");
   exactField(manifest, "license", "MIT", "package.json");
   exactField(manifest, "contentPolicy", { class: "dual-use" }, "package.json");
   exactField(manifest, "type", "module", "package.json");

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -31,7 +31,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.17.1
+  bun add --global @hraness/kb@0.17.2
 }
 kb --help
 ```


### PR DESCRIPTION
## Summary

- publish focused npm discovery metadata and align the README opening with the canonical package description
- add direct npm, GitHub, and project-overview links
- prepare the immutable v0.17.2 skill and package references
- enforce keyword quality and packed metadata identity in the release checks

## Verification

- `bun run check`
- `git diff --check`
- committed `dist/` and `bun.lock` unchanged