### PR TITLE
docs: clarify KB discovery and publishing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ kb history search packages/parser --root . --repo .. --json
 
 ## links
 
-[npm](https://www.npmjs.com/package/@hraness/kb) ·
-[github](https://github.com/hraness/kb) ·
-[overview](https://hraness.com/kb)
+[Install `@hraness/kb` from npm](https://www.npmjs.com/package/@hraness/kb) ·
+[KB source on GitHub](https://github.com/hraness/kb) ·
+[KB overview](https://hraness.com/kb)
 <!-- hraness:kb-landing:end -->
 
 ## A knowledge base for your coding agents

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -6,8 +6,11 @@ initial registry write follows a separate path.
 
 ## Bootstrap the npm package
 
-Start from the current `main` commit after its required checks pass. Use Node
-24, npm 11.19.0, and Bun 1.3.14. Do not create the matching Git tag yet.
+This section records the one-time `0.17.1` bootstrap. Do not reuse the
+interactive path for a later release; follow
+[Stage a later version](#stage-a-later-version) instead. The bootstrap started
+from the checked `main` commit with Node 24, npm 11.19.0, and Bun 1.3.14. The
+matching Git tag was created only after the public package was verified.
 
 1. Install without dependency lifecycle scripts and run the complete gate.
 

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -140,9 +140,9 @@ describe("npm release workflows", () => {
     const opening = readme.slice(0, 1_500).replace(/\s+/gu, " ").toLowerCase();
     expect(opening).toContain(String(manifest.description).toLowerCase());
     for (const link of [
-      "[npm](https://www.npmjs.com/package/@hraness/kb)",
-      "[github](https://github.com/hraness/kb)",
-      "[overview](https://hraness.com/kb)",
+      "[Install `@hraness/kb` from npm](https://www.npmjs.com/package/@hraness/kb)",
+      "[KB source on GitHub](https://github.com/hraness/kb)",
+      "[KB overview](https://hraness.com/kb)",
     ]) expect(readme).toContain(link);
   });
 
@@ -311,6 +311,9 @@ describe("npm release workflows", () => {
     ]);
     for (const required of [
       "automatically starts",
+      "one-time `0.17.1` bootstrap",
+      "Do not reuse the\ninteractive path for a later release",
+      "[Stage a later version](#stage-a-later-version)",
       "version is unchanged",
       "protected `npm-stage` environment",
       "reviewer `0thernet`",
@@ -405,7 +408,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(200);
-      expect(verified.unpackedBytes).toBe(4_860_653);
+      expect(verified.unpackedBytes).toBe(4_860_696);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);


### PR DESCRIPTION
## Summary

- use descriptive npm, GitHub, and overview link text in the README
- mark 0.17.1 as historical one-time npm bootstrap evidence
- keep the package identity byte budget exact after the README change

## Validation

- `bun run check`
- 1,196 tests passed
- package smoke and Rust URL metadata helper check passed
- `git diff --check`