### PR TITLE
release: publish KB 0.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global @hraness/kb@0.17.2
+bun add --global @hraness/kb@0.17.3
 ```
 
 ## Why kb
@@ -185,6 +185,12 @@ Start with a short inherited `AGENTS.md` path for rules whose omission would mak
 
 Treat the knowledge base as repository-adjacent durable memory. Authored Markdown and Git are the record; catalogs, indexes, embeddings, and graph views are replaceable ways to find and inspect it. Checks can validate structure, captures can preserve a selected surface, and similarity can suggest candidates. None of those mechanisms proves that a source is trustworthy or an explanation is still true. People and agents must revise the knowledge as the repository changes.
 
+## Upgrade to v0.17.3
+
+Version 0.17.3 restructures the README around an inspectable first task,
+explicit operating boundaries, and a shorter path from installation to useful
+output. Runtime APIs and package behavior are unchanged.
+
 ## Upgrade to v0.17.2
 
 Version 0.17.2 improves package discovery through focused npm keywords, a more
@@ -234,7 +240,7 @@ Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
 Install the `kb` Agent Skill from hraness/kb with the standard skills CLI. Use
-the skill's runtime instructions to install the exact `@hraness/kb@0.17.2`
+the skill's runtime instructions to install the exact `@hraness/kb@0.17.3`
 registry release only when the command is missing. Verify it with `kb doctor`
 and `kb --help`, but do not initialize or modify a vault until I ask.
 ```
@@ -250,17 +256,17 @@ Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.17.2` npm version.
+CLI from the immutable `@hraness/kb@0.17.3` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.17.2` npm package includes the same tree under
+`0.17.3` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.17.2
+bun add --global @hraness/kb@0.17.3
 kb --help
 kb-evaluation-builder --help
 ```
@@ -268,7 +274,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.17.2
+npm install --global --ignore-scripts @hraness/kb@0.17.3
 kb --help
 ```
 
@@ -281,7 +287,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.17.2
+bun add --exact @hraness/kb@0.17.3
 ```
 
 The resulting dependency should remain exact:
@@ -289,12 +295,12 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.17.2"
+    "@hraness/kb": "0.17.3"
   }
 }
 ```
 
-Version 0.17.2 retains two public GitHub dependencies:
+Version 0.17.3 retains two public GitHub dependencies:
 `@steipete/sweet-cookie` at Hraness release `v0.4.2` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
 `aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior. A

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -131,7 +131,7 @@ keep the tag and npm version immutable. After the recovery workflow is on
 current `main`, dispatch it with the existing tag:
 
 ```sh
-gh workflow run release.yml --ref main -f tag=v0.17.2
+gh workflow run release.yml --ref main -f tag=v0.17.3
 ```
 
 The recovery path accepts only the newest stable repository tag. It freshly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.17.2"
+      "version": "0.17.3"
     }
   ],
   "dependencies": [

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -120,7 +120,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.17.2",
+      version: "0.17.3",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",
@@ -410,7 +410,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(200);
-      expect(verified.unpackedBytes).toBe(4_861_264);
+      expect(verified.unpackedBytes).toBe(4_861_496);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/scripts/npm-stage-selection.test.ts
+++ b/scripts/npm-stage-selection.test.ts
@@ -14,12 +14,12 @@ function manifest(version: unknown, name: unknown = "@hraness/kb"): string {
 describe("npm stage selection", () => {
   test("selects a strictly increasing stable version from a push", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.17.2"),
+      currentManifest: manifest("0.17.3"),
       eventName: "push",
-      previousManifest: manifest("0.17.1"),
+      previousManifest: manifest("0.17.2"),
     })).toEqual({
-      currentVersion: "0.17.2",
-      previousVersion: "0.17.1",
+      currentVersion: "0.17.3",
+      previousVersion: "0.17.2",
       reason: "stable-version-increase",
       shouldStage: true,
     });
@@ -27,12 +27,12 @@ describe("npm stage selection", () => {
 
   test("makes an unrelated package.json edit a successful no-op", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.17.2"),
+      currentManifest: manifest("0.17.3"),
       eventName: "push",
-      previousManifest: manifest("0.17.2"),
+      previousManifest: manifest("0.17.3"),
     })).toEqual({
-      currentVersion: "0.17.2",
-      previousVersion: "0.17.2",
+      currentVersion: "0.17.3",
+      previousVersion: "0.17.3",
       reason: "version-unchanged",
       shouldStage: false,
     });
@@ -40,10 +40,10 @@ describe("npm stage selection", () => {
 
   test("retains a manual current-version recovery request", () => {
     expect(selectNpmStage({
-      currentManifest: manifest("0.17.2"),
+      currentManifest: manifest("0.17.3"),
       eventName: "workflow_dispatch",
     })).toEqual({
-      currentVersion: "0.17.2",
+      currentVersion: "0.17.3",
       reason: "manual-recovery",
       shouldStage: true,
     });
@@ -53,17 +53,17 @@ describe("npm stage selection", () => {
     expect(() => selectNpmStage({
       currentManifest: manifest("0.17.0"),
       eventName: "push",
-      previousManifest: manifest("0.17.2"),
+      previousManifest: manifest("0.17.3"),
     })).toThrow("Package version must increase");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0-beta.1"),
       eventName: "push",
-      previousManifest: manifest("0.17.2"),
+      previousManifest: manifest("0.17.3"),
     })).toThrow("stable semantic version");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0", "@hraness/not-kb"),
       eventName: "push",
-      previousManifest: manifest("0.17.2"),
+      previousManifest: manifest("0.17.3"),
     })).toThrow("must identify @hraness/kb");
     expect(() => selectNpmStage({
       currentManifest: manifest("0.18.0"),
@@ -113,8 +113,8 @@ describe("npm stage selection", () => {
       const previousManifest = join(work, "previous-package.json");
       const githubOutput = join(work, "github-output.txt");
       await Promise.all([
-        writeFile(currentManifest, manifest("0.17.2")),
-        writeFile(previousManifest, manifest("0.17.1")),
+        writeFile(currentManifest, manifest("0.17.3")),
+        writeFile(previousManifest, manifest("0.17.2")),
       ]);
       const child = Bun.spawn([
         process.execPath,
@@ -136,12 +136,12 @@ describe("npm stage selection", () => {
       ]);
       expect(error).toBe("");
       expect(exitCode).toBe(0);
-      expect(output).toContain("Stage @hraness/kb@0.17.2: stable-version-increase");
+      expect(output).toContain("Stage @hraness/kb@0.17.3: stable-version-increase");
       expect(await readFile(githubOutput, "utf8")).toBe(
-        "current_version=0.17.2\n"
+        "current_version=0.17.3\n"
         + "reason=stable-version-increase\n"
         + "should_stage=true\n"
-        + "previous_version=0.17.1\n",
+        + "previous_version=0.17.2\n",
       );
     } finally {
       await rm(work, { force: true, recursive: true });

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -31,7 +31,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.17.2
+  bun add --global @hraness/kb@0.17.3
 }
 kb --help
 ```


### PR DESCRIPTION
## Summary

- bumps @hraness/kb to the stable 0.17.3 patch over README architecture merge #16
- keeps the bundled Agent Skill, install examples, portfolio inventory, and release fixtures on the exact version
- records the README-only upgrade with no runtime API or package behavior change

## Verification

- bun run check
- 1,196 tests passed
- exact 200-file package inventory: 4,861,496 unpacked bytes
- committed dist/ and bun.lock remained unchanged

## Release continuation

Merging automatically stages the exact package through the npm-stage environment. A maintainer must inspect and promote the staged package with npm 2FA before v0.17.3 can be tagged and the immutable GitHub Release can be created.