### PR TITLE
feat: prepare reviewed Oh adoption candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global @hraness/kb@0.17.3
+bun add --global @hraness/kb@0.18.0
 ```
 
 ## Why kb
@@ -193,6 +193,18 @@ Start with a short inherited `AGENTS.md` path for rules whose omission would mak
 
 Treat the knowledge base as repository-adjacent durable memory. Authored Markdown and Git are the record; catalogs, indexes, embeddings, and graph views are replaceable ways to find and inspect it. Checks can validate structure, captures can preserve a selected surface, and similarity can suggest candidates. None of those mechanisms proves that a source is trustworthy or an explanation is still true. People and agents must revise the knowledge as the repository changes.
 
+## Upgrade to v0.18.0
+
+Version 0.18.0 adds a review-only adoption seam for exact dependency closures
+from an Oh working authority. Trusted host code creates a
+`createOhAdoptionPreparerV1` facade with the expected binding and head,
+destination, rights clearance, review route, and conflict policy. The narrow
+`prepare` call accepts only a capsule plus transformation and redaction
+disclosures, returns deeply immutable deterministic Markdown and manifest
+bytes with status `prepared`, and has no vault, Git, Oh-store, or promotion
+capability. KB pins `@hraness/oh` v0.2.0 and delegates closure integrity to its
+official store verifier.
+
 ## Upgrade to v0.17.3
 
 Version 0.17.3 restructures the README around an inspectable first task,
@@ -247,9 +259,9 @@ audit projection disposable.
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.17.3` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.18.0` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
-`@hraness/kb@0.17.3` registry release only when the command is missing. Verify it
+`@hraness/kb@0.18.0` registry release only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
 I ask.
 ```
@@ -257,25 +269,25 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.17.3
-bunx skills add hraness/kb#v0.17.3
+npx skills add hraness/kb#v0.18.0
+bunx skills add hraness/kb#v0.18.0
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.17.3` npm version.
+CLI from the immutable `@hraness/kb@0.18.0` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.17.3` npm package includes the same tree under
+`0.18.0` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.17.3
+bun add --global @hraness/kb@0.18.0
 kb --help
 kb-evaluation-builder --help
 ```
@@ -283,7 +295,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.17.3
+npm install --global --ignore-scripts @hraness/kb@0.18.0
 kb --help
 ```
 
@@ -296,7 +308,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.17.3
+bun add --exact @hraness/kb@0.18.0
 ```
 
 The resulting dependency should remain exact:
@@ -304,12 +316,13 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.17.3"
+    "@hraness/kb": "0.18.0"
   }
 }
 ```
 
-Version 0.17.3 retains two public GitHub dependencies:
+Version 0.18.0 retains three public GitHub dependencies: `@hraness/oh` at
+immutable release `v0.2.0` for closure verification,
 `@steipete/sweet-cookie` at Hraness release `v0.4.2` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
 `aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior. A
@@ -572,9 +585,9 @@ a vault. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.17.3
+npx skills add hraness/kb#v0.18.0
 # or
-bunx skills add hraness/kb#v0.17.3
+bunx skills add hraness/kb#v0.18.0
 ```
 
 The skill invokes the installed `kb` command without depending on a repository

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@hraness/kb",
       "dependencies": {
+        "@hraness/oh": "github:hraness/oh#v0.2.0",
         "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
         "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
         "agent-browser": "0.32.3",
@@ -21,6 +22,8 @@
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
+
+    "@hraness/oh": ["@hraness/oh@github:hraness/oh#89fb133", { "peerDependencies": { "@libsql/client": ">=0.17.4 <1", "@suss/datalog": "0.20.0", "@tobilu/qmd": "2.5.3" }, "optionalPeers": ["@libsql/client", "@suss/datalog", "@tobilu/qmd"], "bin": { "oh": "./dist/cli.js" } }, "hraness-oh-89fb133", "sha512-huk8DqOAhnwMm4QAOU+JiyxfdfUF0pZth1jnzOkOmZQe6NqZjR+LXAe2swIVdBMn1hCHb47+c7IqFH3QUTBWTQ=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -364,8 +364,11 @@ function recordKey(value) {
 function orderedUnique(values) {
   return values.every((value, index) => index === 0 || values[index - 1] < value);
 }
+function unsafeReviewCodePoint(codePoint) {
+  return codePoint <= 31 || codePoint >= 127 && codePoint <= 159 || codePoint === 1564 || codePoint === 8206 || codePoint === 8207 || codePoint >= 8232 && codePoint <= 8238 || codePoint >= 8294 && codePoint <= 8297 || codePoint === 65279;
+}
 function singleLine(value) {
-  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value) || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES)
+  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value || !validUnicode(value) || [...value].some((character) => unsafeReviewCodePoint(character.codePointAt(0) ?? 0)) || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES)
     return null;
   return value;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -245,6 +245,486 @@ import {
   wikiLinks
 } from "./index-cxfrakt7.js";
 import"./index-1xxnjn0d.js";
+// src/oh-adoption.ts
+import { createHash } from "crypto";
+import { posix } from "path";
+var SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+var CODE_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
+var RECORD_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
+var MAX_CAPSULE_BYTES = 16 * 1024 * 1024;
+var MAX_RECORDS = 1024;
+var MAX_ROOTS = 256;
+var MAX_RECORD_BYTES = 1024 * 1024;
+var MAX_DEPENDENCIES = 4096;
+var MAX_TEXT_BYTES = 4096;
+var MAX_STRUCTURAL_NODES = 262144;
+var MAX_STRUCTURAL_DEPTH = 128;
+var OH_RECORD_KINDS = new Set([
+  "activity",
+  "assertion",
+  "context",
+  "dependency-manifest",
+  "edition",
+  "entity",
+  "evidence",
+  "identity-operation",
+  "inquiry",
+  "inquiry-event",
+  "review-decision",
+  "rights-decision",
+  "schema",
+  "shape",
+  "statement",
+  "type-membership",
+  "view",
+  "vocabulary"
+]);
+function isRecord(value) {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+function exactKeys(value, keys) {
+  const actual = Reflect.ownKeys(value);
+  return actual.length === keys.length && actual.every((key) => {
+    if (typeof key !== "string" || !keys.includes(key))
+      return false;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor !== undefined && descriptor.enumerable && "value" in descriptor;
+  });
+}
+function validUnicode(value) {
+  for (let index = 0;index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 55296 && code <= 56319) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 56320 || next > 57343)
+        return false;
+      index += 1;
+    } else if (code >= 56320 && code <= 57343)
+      return false;
+  }
+  return true;
+}
+function canonicalJson(value, path = "$", ancestors = new Set) {
+  if (value === null || typeof value === "boolean")
+    return JSON.stringify(value);
+  if (typeof value === "string") {
+    if (!validUnicode(value))
+      throw new TypeError(`${path} contains invalid Unicode.`);
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Object.is(value, -0))
+      throw new TypeError(`${path} is not a canonical number.`);
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object" || value === null || ancestors.has(value)) {
+    throw new TypeError(`${path} is not an acyclic JSON value.`);
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const keys2 = Reflect.ownKeys(value);
+      if (keys2.some((key) => key !== "length" && (typeof key !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= value.length))) {
+        throw new TypeError(`${path} has non-index array properties.`);
+      }
+      const output = [];
+      for (let index = 0;index < value.length; index += 1) {
+        if (!Object.hasOwn(value, index))
+          throw new TypeError(`${path} contains a sparse array.`);
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+          throw new TypeError(`${path}[${index}] is not an enumerable data property.`);
+        }
+        output.push(canonicalJson(descriptor.value, `${path}[${index}]`, ancestors));
+      }
+      return `[${output.join(",")}]`;
+    }
+    if (!isRecord(value))
+      throw new TypeError(`${path} is not a plain JSON object.`);
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.some((key) => typeof key !== "string"))
+      throw new TypeError(`${path} has symbol properties.`);
+    const keys = ownKeys;
+    keys.sort();
+    return `{${keys.map((key) => {
+      if (!validUnicode(key))
+        throw new TypeError(`${path} contains an invalid key.`);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+        throw new TypeError(`${path}.${key} is not an enumerable data property.`);
+      }
+      return `${JSON.stringify(key)}:${canonicalJson(descriptor.value, `${path}.${key}`, ancestors)}`;
+    }).join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+function digest(value) {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+function structurallyBounded(value) {
+  const pending = [[value, 0]];
+  const seen = new Set;
+  let nodes = 0;
+  while (pending.length > 0) {
+    const [candidate, depth] = pending.pop();
+    nodes += 1;
+    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH)
+      return false;
+    if (typeof candidate === "string" && Buffer.byteLength(candidate, "utf8") > MAX_CAPSULE_BYTES)
+      return false;
+    if (typeof candidate !== "object" || candidate === null)
+      continue;
+    if (seen.has(candidate))
+      return false;
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      if (candidate.length > MAX_STRUCTURAL_NODES)
+        return false;
+      const keys = Reflect.ownKeys(candidate);
+      if (keys.some((key) => key !== "length" && (typeof key !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= candidate.length)))
+        return false;
+      for (let index = 0;index < candidate.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, String(index));
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor))
+          return false;
+        pending.push([descriptor.value, depth + 1]);
+      }
+    } else if (isRecord(candidate)) {
+      const keys = Reflect.ownKeys(candidate);
+      if (keys.length > MAX_STRUCTURAL_NODES || keys.some((key) => typeof key !== "string"))
+        return false;
+      for (const key of keys) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor))
+          return false;
+        pending.push([descriptor.value, depth + 1]);
+      }
+    } else
+      return false;
+  }
+  return true;
+}
+function sha(value) {
+  return typeof value === "string" && SHA256_PATTERN.test(value) ? value : null;
+}
+function code(value, maximum = 256) {
+  return typeof value === "string" && value.length <= maximum && CODE_PATTERN.test(value) ? value : null;
+}
+function recordKey(value) {
+  return typeof value === "string" && value.length <= 512 && RECORD_KEY_PATTERN.test(value) ? value : null;
+}
+function orderedUnique(values) {
+  return values.every((value, index) => index === 0 || values[index - 1] < value);
+}
+function parseProfile(value) {
+  if (!isRecord(value) || !exactKeys(value, [
+    "applicationProfileSha256",
+    "capabilities",
+    "profileId",
+    "profileKind",
+    "profileSha256",
+    "v"
+  ]) || value.v !== 1 || value.profileKind !== "working" || !isRecord(value.capabilities) || !exactKeys(value.capabilities, [
+    "changesSince",
+    "dependencyClosureExport",
+    "exactSnapshots",
+    "operationReplication",
+    "semanticBundleCommit",
+    "v",
+    "wholeSpacePurge"
+  ]))
+    return null;
+  const capabilities = value.capabilities;
+  if (capabilities.changesSince !== true || capabilities.dependencyClosureExport !== true || capabilities.exactSnapshots !== true || capabilities.operationReplication !== false || capabilities.semanticBundleCommit !== true || capabilities.v !== 1 || capabilities.wholeSpacePurge !== true)
+    return null;
+  const applicationProfileSha256 = value.applicationProfileSha256 === null ? null : sha(value.applicationProfileSha256);
+  const profileId = code(value.profileId);
+  const profileSha256 = sha(value.profileSha256);
+  if (value.applicationProfileSha256 !== null && applicationProfileSha256 === null || profileId === null || profileSha256 === null)
+    return null;
+  const payload = { applicationProfileSha256, capabilities: {
+    changesSince: true,
+    dependencyClosureExport: true,
+    exactSnapshots: true,
+    operationReplication: false,
+    semanticBundleCommit: true,
+    v: 1,
+    wholeSpacePurge: true
+  }, profileId, profileKind: "working", v: 1 };
+  return digest(payload) === profileSha256 ? { ...payload, profileSha256 } : null;
+}
+function parseBinding(value) {
+  if (!isRecord(value) || !exactKeys(value, [
+    "bindingSha256",
+    "contractSha256",
+    "profile",
+    "realmId",
+    "spaceId",
+    "v"
+  ]) || value.v !== 1)
+    return null;
+  const bindingSha256 = sha(value.bindingSha256);
+  const contractSha256 = sha(value.contractSha256);
+  const profile = parseProfile(value.profile);
+  const realmId = code(value.realmId);
+  const spaceId = code(value.spaceId);
+  if (bindingSha256 === null || contractSha256 === null || profile === null || realmId === null || spaceId === null) {
+    return null;
+  }
+  const payload = { contractSha256, profile, realmId, spaceId, v: 1 };
+  return digest(payload) === bindingSha256 ? { ...payload, bindingSha256 } : null;
+}
+function parseHead(value) {
+  if (!isRecord(value) || !exactKeys(value, [
+    "generation",
+    "graphRevisionSha256",
+    "operationSha256",
+    "recordsSha256",
+    "sequence",
+    "v"
+  ]) || value.v !== 1)
+    return null;
+  const generation = Number.isSafeInteger(value.generation) && value.generation >= 0 ? value.generation : null;
+  const sequence = Number.isSafeInteger(value.sequence) && value.sequence >= 0 ? value.sequence : null;
+  const graphRevisionSha256 = value.graphRevisionSha256 === null ? null : sha(value.graphRevisionSha256);
+  const operationSha256 = value.operationSha256 === null ? null : sha(value.operationSha256);
+  const recordsSha256 = sha(value.recordsSha256);
+  return generation !== null && generation === sequence && recordsSha256 !== null && (value.graphRevisionSha256 === null || graphRevisionSha256 !== null) && (value.operationSha256 === null || operationSha256 !== null) && sequence === 0 === (operationSha256 === null) && sequence === 0 === (graphRevisionSha256 === null) ? { generation, graphRevisionSha256, operationSha256, recordsSha256, sequence, v: 1 } : null;
+}
+function parseRecord(value) {
+  if (!isRecord(value) || !exactKeys(value, ["dependencies", "key", "kind", "recordSha256", "v", "value"]) || value.v !== 1 || !Array.isArray(value.dependencies) || value.dependencies.length > MAX_DEPENDENCIES || !OH_RECORD_KINDS.has(value.kind) || !structurallyBounded(value.value))
+    return null;
+  const key = recordKey(value.key);
+  const kind = typeof value.kind === "string" ? value.kind : null;
+  const recordSha256 = sha(value.recordSha256);
+  const dependencies = value.dependencies.map(recordKey);
+  if (key === null || kind === null || recordSha256 === null || dependencies.some((item) => item === null) || !orderedUnique(dependencies) || dependencies.includes(key))
+    return null;
+  const payload = {
+    dependencies,
+    key,
+    kind,
+    v: 1,
+    value: value.value
+  };
+  const encoded = canonicalJson(payload.value);
+  return Buffer.byteLength(encoded, "utf8") <= MAX_RECORD_BYTES && digest(payload) === recordSha256 ? { ...payload, recordSha256 } : null;
+}
+function parseExpectedSource(value) {
+  if (!isRecord(value) || !exactKeys(value, ["authorityId", "binding", "head", "v"]) || value.v !== 1)
+    return null;
+  const authorityId = code(value.authorityId);
+  const binding = parseBinding(value.binding);
+  const head = parseHead(value.head);
+  return authorityId !== null && binding !== null && head !== null ? { authorityId, binding, head, v: 1 } : null;
+}
+function parseOhDependencyClosureCapsuleV1(value, expectedSource) {
+  try {
+    if (!structurallyBounded(value) || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES || !isRecord(value) || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"]) || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots) || value.records.length < 1 || value.records.length > MAX_RECORDS || value.roots.length < 1 || value.roots.length > MAX_ROOTS)
+      return null;
+    const expected = parseExpectedSource(expectedSource);
+    const binding = parseBinding(value.binding);
+    const head = parseHead(value.head);
+    const closureSha256 = sha(value.closureSha256);
+    const roots = value.roots.map(recordKey);
+    const records = value.records.map(parseRecord);
+    if (expected === null || binding === null || head === null || closureSha256 === null || roots.some((root) => root === null) || !orderedUnique(roots) || records.some((record) => record === null))
+      return null;
+    const parsedRecords = records;
+    if (!orderedUnique(parsedRecords.map((record) => record.key)))
+      return null;
+    if (canonicalJson(binding) !== canonicalJson(expected.binding) || canonicalJson(head) !== canonicalJson(expected.head))
+      return null;
+    const byKey = new Map(parsedRecords.map((record) => [record.key, record]));
+    const reachable = new Set;
+    const pending = [...roots];
+    while (pending.length > 0) {
+      const key = pending.pop();
+      if (reachable.has(key))
+        continue;
+      const record = byKey.get(key);
+      if (record === undefined)
+        return null;
+      reachable.add(key);
+      pending.push(...record.dependencies);
+    }
+    if (reachable.size !== parsedRecords.length)
+      return null;
+    const payload = { binding, head, records: parsedRecords, roots, v: 1 };
+    return digest(payload) === closureSha256 ? { ...payload, closureSha256 } : null;
+  } catch {
+    return null;
+  }
+}
+function singleLine(value) {
+  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value) || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES)
+    return null;
+  return value;
+}
+function parseDestination(value) {
+  if (!isRecord(value) || !exactKeys(value, ["purpose", "targetPath", "v"]) || value.v !== 1)
+    return null;
+  const purpose = code(value.purpose);
+  if (purpose === null || typeof value.targetPath !== "string" || value.targetPath.length > 512 || value.targetPath.includes("\\") || value.targetPath.startsWith("/") || posix.normalize(value.targetPath) !== value.targetPath || !/^notes\/[a-z0-9][a-z0-9._/-]*\.md$/u.test(value.targetPath) || value.targetPath.split("/").some((segment) => segment === "." || segment === ".." || segment.startsWith("."))) {
+    return null;
+  }
+  return { purpose, targetPath: value.targetPath, v: 1 };
+}
+function parseRights(value, purpose) {
+  if (!isRecord(value) || !exactKeys(value, ["decisionId", "disposition", "purpose", "v"]) || value.v !== 1 || value.disposition !== "cleared-for-purpose" || value.purpose !== purpose)
+    return null;
+  const decisionId = code(value.decisionId);
+  return decisionId === null ? null : { decisionId, disposition: "cleared-for-purpose", purpose, v: 1 };
+}
+function parseReview(value) {
+  if (!isRecord(value) || !exactKeys(value, ["route", "status", "v"]) || value.v !== 1 || value.status !== "required")
+    return null;
+  const route = code(value.route);
+  return route === null ? null : { route, status: "required", v: 1 };
+}
+function parseConflicts(value) {
+  if (!isRecord(value) || !exactKeys(value, ["notes", "status", "v"]) || value.v !== 1 || value.status !== "none-observed" && value.status !== "requires-resolution" || !Array.isArray(value.notes) || value.notes.length < 1 || value.notes.length > 64)
+    return null;
+  const notes = value.notes.map(singleLine);
+  if (notes.some((note) => note === null))
+    return null;
+  const sorted = [...notes].sort();
+  return orderedUnique(sorted) ? { notes: sorted, status: value.status, v: 1 } : null;
+}
+function parseDisclosures(value, keys) {
+  if (!Array.isArray(value) || value.length > 256)
+    return null;
+  const parsed = [];
+  for (const item of value) {
+    if (!isRecord(item) || !exactKeys(item, ["id", "recordKey", "summary", "v"]) || item.v !== 1)
+      return null;
+    const id = code(item.id);
+    const key = recordKey(item.recordKey);
+    const summary = singleLine(item.summary);
+    if (id === null || key === null || summary === null || !keys.has(key))
+      return null;
+    parsed.push({ id, recordKey: key, summary, v: 1 });
+  }
+  parsed.sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+  return orderedUnique(parsed.map((item) => item.id)) ? parsed : null;
+}
+function markdownEscape(value) {
+  return value.replace(/[\\`*_{}\[\]<>()#+.!|>-]/gu, "\\$&");
+}
+function renderMarkdown(manifest, candidateSha256) {
+  const lines = [
+    "# Oh adoption candidate",
+    "",
+    `- Status: \`${manifest.status}\``,
+    `- Candidate: \`sha256:${candidateSha256}\``,
+    `- Destination: \`${manifest.destination.targetPath}\``,
+    `- Purpose: \`${manifest.destination.purpose}\``,
+    `- Source authority: \`${manifest.source.authorityId}\``,
+    `- Source binding: \`${manifest.source.binding.bindingSha256}\``,
+    `- Source head sequence: \`${manifest.source.head.sequence}\``,
+    `- Source head operation: \`${manifest.source.head.operationSha256 ?? "empty"}\``,
+    `- Source graph revision: \`${manifest.source.head.graphRevisionSha256 ?? "empty"}\``,
+    `- Source records digest: \`${manifest.source.head.recordsSha256}\``,
+    `- Closure: \`${manifest.source.closureSha256}\``,
+    "",
+    "This is a review candidate, not reviewed knowledge. It does not mutate a vault or adopt the source operation chain, database, projection, or derived tuples.",
+    "",
+    "## Required decisions",
+    "",
+    `- Rights: \`${manifest.rights.disposition}\` via \`${manifest.rights.decisionId}\` for \`${manifest.rights.purpose}\``,
+    `- Review: \`${manifest.review.status}\` via \`${manifest.review.route}\``,
+    `- Conflicts: \`${manifest.conflicts.status}\``,
+    ...manifest.conflicts.notes.map((note) => `  - ${markdownEscape(note)}`),
+    "",
+    "## Selected roots",
+    "",
+    ...manifest.source.roots.map((root) => `- \`${root}\``),
+    "",
+    "## Exact source records",
+    ""
+  ];
+  for (const record of manifest.source.records) {
+    lines.push(`### \`${record.key}\``, "", `- Kind: \`${record.kind}\``, `- Digest: \`${record.recordSha256}\``, `- Dependencies: ${record.dependencies.length === 0 ? "none" : record.dependencies.map((key) => `\`${key}\``).join(", ")}`, "");
+  }
+  lines.push("## Transformations", "", ...manifest.transformations.length === 0 ? ["- None declared."] : manifest.transformations.map((item) => `- \`${item.id}\` on \`${item.recordKey}\`: ${markdownEscape(item.summary)}`), "", "## Redactions", "", ...manifest.redactions.length === 0 ? ["- None declared."] : manifest.redactions.map((item) => `- \`${item.id}\` on \`${item.recordKey}\`: ${markdownEscape(item.summary)}`), "");
+  return `${lines.join(`
+`)}
+`;
+}
+function prepareOhAdoptionCandidateV1(value) {
+  if (!isRecord(value) || !exactKeys(value, [
+    "capsule",
+    "conflicts",
+    "destination",
+    "expectedSource",
+    "redactions",
+    "review",
+    "rights",
+    "transformations",
+    "v"
+  ]) || value.v !== 1) {
+    throw new TypeError("Invalid Oh adoption candidate input.");
+  }
+  const expectedSource = parseExpectedSource(value.expectedSource);
+  const capsule = parseOhDependencyClosureCapsuleV1(value.capsule, value.expectedSource);
+  const destination = parseDestination(value.destination);
+  if (expectedSource === null || capsule === null || destination === null) {
+    throw new TypeError("The source capsule or destination is invalid.");
+  }
+  const rights = parseRights(value.rights, destination.purpose);
+  const review = parseReview(value.review);
+  const conflicts = parseConflicts(value.conflicts);
+  const recordKeys = new Set(capsule.records.map((record) => record.key));
+  const transformations = parseDisclosures(value.transformations, recordKeys);
+  const redactions = parseDisclosures(value.redactions, recordKeys);
+  const roots = new Set(capsule.roots);
+  if (rights === null || review === null || conflicts === null || transformations === null || redactions === null || capsule.records.filter((record) => roots.has(record.key)).every((record) => record.kind === "view")) {
+    throw new TypeError("Adoption requires rights, review, conflict, and authoritative-root declarations.");
+  }
+  const source = {
+    authorityId: expectedSource.authorityId,
+    binding: capsule.binding,
+    closureSha256: capsule.closureSha256,
+    head: capsule.head,
+    records: capsule.records.map((record) => ({
+      dependencies: record.dependencies,
+      key: record.key,
+      kind: record.kind,
+      recordSha256: record.recordSha256,
+      v: 1
+    })),
+    roots: capsule.roots,
+    v: 1
+  };
+  const manifest = {
+    conflicts,
+    destination,
+    format: "hraness.kb.oh-adoption-candidate.v1",
+    redactions,
+    review,
+    rights,
+    source,
+    status: "prepared",
+    transformations,
+    v: 1
+  };
+  const candidateSha256 = digest(manifest);
+  const markdown = renderMarkdown(manifest, candidateSha256);
+  if (Buffer.byteLength(markdown, "utf8") > MAX_CAPSULE_BYTES) {
+    throw new RangeError("The adoption candidate exceeds its Markdown byte limit.");
+  }
+  return {
+    artifactSha256: createHash("sha256").update(markdown).digest("hex"),
+    candidateSha256,
+    manifest,
+    markdown,
+    v: 1
+  };
+}
 export {
   workflowFromUnknown,
   wikiLinks,
@@ -282,9 +762,11 @@ export {
   readVaultNotes,
   queryVault,
   qmdIndexerVersion,
+  prepareOhAdoptionCandidateV1,
   planStatuses,
   percolateVault,
   parseRetrievalEvaluationCorpus,
+  parseOhDependencyClosureCapsuleV1,
   parseNote,
   parseLocalAttachmentReferences,
   parseGitHistoryOutput,

--- a/dist/index.js
+++ b/dist/index.js
@@ -248,37 +248,20 @@ import"./index-1xxnjn0d.js";
 // src/oh-adoption.ts
 import { createHash } from "crypto";
 import { posix } from "path";
-var SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+import { canonicalJson, canonicalSha256 } from "@hraness/oh";
+import {
+  parseOhHeadV1,
+  parseOhStoreBindingV1,
+  verifyOhDependencyClosureAgainstV1
+} from "@hraness/oh/store";
 var CODE_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
 var RECORD_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
 var MAX_CAPSULE_BYTES = 16 * 1024 * 1024;
 var MAX_RECORDS = 1024;
 var MAX_ROOTS = 256;
-var MAX_RECORD_BYTES = 1024 * 1024;
-var MAX_DEPENDENCIES = 4096;
 var MAX_TEXT_BYTES = 4096;
 var MAX_STRUCTURAL_NODES = 262144;
 var MAX_STRUCTURAL_DEPTH = 128;
-var OH_RECORD_KINDS = new Set([
-  "activity",
-  "assertion",
-  "context",
-  "dependency-manifest",
-  "edition",
-  "entity",
-  "evidence",
-  "identity-operation",
-  "inquiry",
-  "inquiry-event",
-  "review-decision",
-  "rights-decision",
-  "schema",
-  "shape",
-  "statement",
-  "type-membership",
-  "view",
-  "vocabulary"
-]);
 function isRecord(value) {
   if (typeof value !== "object" || value === null || Array.isArray(value))
     return false;
@@ -307,75 +290,24 @@ function validUnicode(value) {
   }
   return true;
 }
-function canonicalJson(value, path = "$", ancestors = new Set) {
-  if (value === null || typeof value === "boolean")
-    return JSON.stringify(value);
-  if (typeof value === "string") {
-    if (!validUnicode(value))
-      throw new TypeError(`${path} contains invalid Unicode.`);
-    return JSON.stringify(value);
-  }
-  if (typeof value === "number") {
-    if (!Number.isFinite(value) || Object.is(value, -0))
-      throw new TypeError(`${path} is not a canonical number.`);
-    return JSON.stringify(value);
-  }
-  if (typeof value !== "object" || value === null || ancestors.has(value)) {
-    throw new TypeError(`${path} is not an acyclic JSON value.`);
-  }
-  ancestors.add(value);
-  try {
-    if (Array.isArray(value)) {
-      const keys2 = Reflect.ownKeys(value);
-      if (keys2.some((key) => key !== "length" && (typeof key !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= value.length))) {
-        throw new TypeError(`${path} has non-index array properties.`);
-      }
-      const output = [];
-      for (let index = 0;index < value.length; index += 1) {
-        if (!Object.hasOwn(value, index))
-          throw new TypeError(`${path} contains a sparse array.`);
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
-          throw new TypeError(`${path}[${index}] is not an enumerable data property.`);
-        }
-        output.push(canonicalJson(descriptor.value, `${path}[${index}]`, ancestors));
-      }
-      return `[${output.join(",")}]`;
-    }
-    if (!isRecord(value))
-      throw new TypeError(`${path} is not a plain JSON object.`);
-    const ownKeys = Reflect.ownKeys(value);
-    if (ownKeys.some((key) => typeof key !== "string"))
-      throw new TypeError(`${path} has symbol properties.`);
-    const keys = ownKeys;
-    keys.sort();
-    return `{${keys.map((key) => {
-      if (!validUnicode(key))
-        throw new TypeError(`${path} contains an invalid key.`);
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
-        throw new TypeError(`${path}.${key} is not an enumerable data property.`);
-      }
-      return `${JSON.stringify(key)}:${canonicalJson(descriptor.value, `${path}.${key}`, ancestors)}`;
-    }).join(",")}}`;
-  } finally {
-    ancestors.delete(value);
-  }
-}
-function digest(value) {
-  return createHash("sha256").update(canonicalJson(value)).digest("hex");
-}
 function structurallyBounded(value) {
   const pending = [[value, 0]];
   const seen = new Set;
   let nodes = 0;
+  let scalarBytes = 0;
   while (pending.length > 0) {
     const [candidate, depth] = pending.pop();
     nodes += 1;
-    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH)
+    scalarBytes += 4;
+    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH || scalarBytes > MAX_CAPSULE_BYTES)
       return false;
-    if (typeof candidate === "string" && Buffer.byteLength(candidate, "utf8") > MAX_CAPSULE_BYTES)
-      return false;
+    if (typeof candidate === "string") {
+      if (!validUnicode(candidate))
+        return false;
+      scalarBytes += Buffer.byteLength(candidate, "utf8");
+      if (scalarBytes > MAX_CAPSULE_BYTES)
+        return false;
+    }
     if (typeof candidate !== "object" || candidate === null)
       continue;
     if (seen.has(candidate))
@@ -399,7 +331,10 @@ function structurallyBounded(value) {
         return false;
       for (const key of keys) {
         const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
-        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor))
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor) || !validUnicode(key))
+          return false;
+        scalarBytes += Buffer.byteLength(key, "utf8");
+        if (scalarBytes > MAX_CAPSULE_BYTES)
           return false;
         pending.push([descriptor.value, depth + 1]);
       }
@@ -408,8 +343,17 @@ function structurallyBounded(value) {
   }
   return true;
 }
-function sha(value) {
-  return typeof value === "string" && SHA256_PATTERN.test(value) ? value : null;
+function immutableClone(value) {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((item) => immutableClone(item)));
+  }
+  if (isRecord(value)) {
+    const clone = {};
+    for (const key of Object.keys(value))
+      clone[key] = immutableClone(value[key]);
+    return Object.freeze(clone);
+  }
+  return value;
 }
 function code(value, maximum = 256) {
   return typeof value === "string" && value.length <= maximum && CODE_PATTERN.test(value) ? value : null;
@@ -420,150 +364,18 @@ function recordKey(value) {
 function orderedUnique(values) {
   return values.every((value, index) => index === 0 || values[index - 1] < value);
 }
-function parseProfile(value) {
-  if (!isRecord(value) || !exactKeys(value, [
-    "applicationProfileSha256",
-    "capabilities",
-    "profileId",
-    "profileKind",
-    "profileSha256",
-    "v"
-  ]) || value.v !== 1 || value.profileKind !== "working" || !isRecord(value.capabilities) || !exactKeys(value.capabilities, [
-    "changesSince",
-    "dependencyClosureExport",
-    "exactSnapshots",
-    "operationReplication",
-    "semanticBundleCommit",
-    "v",
-    "wholeSpacePurge"
-  ]))
+function singleLine(value) {
+  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value) || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES)
     return null;
-  const capabilities = value.capabilities;
-  if (capabilities.changesSince !== true || capabilities.dependencyClosureExport !== true || capabilities.exactSnapshots !== true || capabilities.operationReplication !== false || capabilities.semanticBundleCommit !== true || capabilities.v !== 1 || capabilities.wholeSpacePurge !== true)
-    return null;
-  const applicationProfileSha256 = value.applicationProfileSha256 === null ? null : sha(value.applicationProfileSha256);
-  const profileId = code(value.profileId);
-  const profileSha256 = sha(value.profileSha256);
-  if (value.applicationProfileSha256 !== null && applicationProfileSha256 === null || profileId === null || profileSha256 === null)
-    return null;
-  const payload = { applicationProfileSha256, capabilities: {
-    changesSince: true,
-    dependencyClosureExport: true,
-    exactSnapshots: true,
-    operationReplication: false,
-    semanticBundleCommit: true,
-    v: 1,
-    wholeSpacePurge: true
-  }, profileId, profileKind: "working", v: 1 };
-  return digest(payload) === profileSha256 ? { ...payload, profileSha256 } : null;
-}
-function parseBinding(value) {
-  if (!isRecord(value) || !exactKeys(value, [
-    "bindingSha256",
-    "contractSha256",
-    "profile",
-    "realmId",
-    "spaceId",
-    "v"
-  ]) || value.v !== 1)
-    return null;
-  const bindingSha256 = sha(value.bindingSha256);
-  const contractSha256 = sha(value.contractSha256);
-  const profile = parseProfile(value.profile);
-  const realmId = code(value.realmId);
-  const spaceId = code(value.spaceId);
-  if (bindingSha256 === null || contractSha256 === null || profile === null || realmId === null || spaceId === null) {
-    return null;
-  }
-  const payload = { contractSha256, profile, realmId, spaceId, v: 1 };
-  return digest(payload) === bindingSha256 ? { ...payload, bindingSha256 } : null;
-}
-function parseHead(value) {
-  if (!isRecord(value) || !exactKeys(value, [
-    "generation",
-    "graphRevisionSha256",
-    "operationSha256",
-    "recordsSha256",
-    "sequence",
-    "v"
-  ]) || value.v !== 1)
-    return null;
-  const generation = Number.isSafeInteger(value.generation) && value.generation >= 0 ? value.generation : null;
-  const sequence = Number.isSafeInteger(value.sequence) && value.sequence >= 0 ? value.sequence : null;
-  const graphRevisionSha256 = value.graphRevisionSha256 === null ? null : sha(value.graphRevisionSha256);
-  const operationSha256 = value.operationSha256 === null ? null : sha(value.operationSha256);
-  const recordsSha256 = sha(value.recordsSha256);
-  return generation !== null && generation === sequence && recordsSha256 !== null && (value.graphRevisionSha256 === null || graphRevisionSha256 !== null) && (value.operationSha256 === null || operationSha256 !== null) && sequence === 0 === (operationSha256 === null) && sequence === 0 === (graphRevisionSha256 === null) ? { generation, graphRevisionSha256, operationSha256, recordsSha256, sequence, v: 1 } : null;
-}
-function parseRecord(value) {
-  if (!isRecord(value) || !exactKeys(value, ["dependencies", "key", "kind", "recordSha256", "v", "value"]) || value.v !== 1 || !Array.isArray(value.dependencies) || value.dependencies.length > MAX_DEPENDENCIES || !OH_RECORD_KINDS.has(value.kind) || !structurallyBounded(value.value))
-    return null;
-  const key = recordKey(value.key);
-  const kind = typeof value.kind === "string" ? value.kind : null;
-  const recordSha256 = sha(value.recordSha256);
-  const dependencies = value.dependencies.map(recordKey);
-  if (key === null || kind === null || recordSha256 === null || dependencies.some((item) => item === null) || !orderedUnique(dependencies) || dependencies.includes(key))
-    return null;
-  const payload = {
-    dependencies,
-    key,
-    kind,
-    v: 1,
-    value: value.value
-  };
-  const encoded = canonicalJson(payload.value);
-  return Buffer.byteLength(encoded, "utf8") <= MAX_RECORD_BYTES && digest(payload) === recordSha256 ? { ...payload, recordSha256 } : null;
+  return value;
 }
 function parseExpectedSource(value) {
   if (!isRecord(value) || !exactKeys(value, ["authorityId", "binding", "head", "v"]) || value.v !== 1)
     return null;
   const authorityId = code(value.authorityId);
-  const binding = parseBinding(value.binding);
-  const head = parseHead(value.head);
-  return authorityId !== null && binding !== null && head !== null ? { authorityId, binding, head, v: 1 } : null;
-}
-function parseOhDependencyClosureCapsuleV1(value, expectedSource) {
-  try {
-    if (!structurallyBounded(value) || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES || !isRecord(value) || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"]) || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots) || value.records.length < 1 || value.records.length > MAX_RECORDS || value.roots.length < 1 || value.roots.length > MAX_ROOTS)
-      return null;
-    const expected = parseExpectedSource(expectedSource);
-    const binding = parseBinding(value.binding);
-    const head = parseHead(value.head);
-    const closureSha256 = sha(value.closureSha256);
-    const roots = value.roots.map(recordKey);
-    const records = value.records.map(parseRecord);
-    if (expected === null || binding === null || head === null || closureSha256 === null || roots.some((root) => root === null) || !orderedUnique(roots) || records.some((record) => record === null))
-      return null;
-    const parsedRecords = records;
-    if (!orderedUnique(parsedRecords.map((record) => record.key)))
-      return null;
-    if (canonicalJson(binding) !== canonicalJson(expected.binding) || canonicalJson(head) !== canonicalJson(expected.head))
-      return null;
-    const byKey = new Map(parsedRecords.map((record) => [record.key, record]));
-    const reachable = new Set;
-    const pending = [...roots];
-    while (pending.length > 0) {
-      const key = pending.pop();
-      if (reachable.has(key))
-        continue;
-      const record = byKey.get(key);
-      if (record === undefined)
-        return null;
-      reachable.add(key);
-      pending.push(...record.dependencies);
-    }
-    if (reachable.size !== parsedRecords.length)
-      return null;
-    const payload = { binding, head, records: parsedRecords, roots, v: 1 };
-    return digest(payload) === closureSha256 ? { ...payload, closureSha256 } : null;
-  } catch {
-    return null;
-  }
-}
-function singleLine(value) {
-  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value) || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES)
-    return null;
-  return value;
+  const binding = parseOhStoreBindingV1(value.binding);
+  const head = parseOhHeadV1(value.head);
+  return authorityId !== null && binding !== null && binding.profile.profileKind === "working" && head !== null ? immutableClone({ authorityId, binding, head, v: 1 }) : null;
 }
 function parseDestination(value) {
   if (!isRecord(value) || !exactKeys(value, ["purpose", "targetPath", "v"]) || value.v !== 1)
@@ -594,6 +406,29 @@ function parseConflicts(value) {
     return null;
   const sorted = [...notes].sort();
   return orderedUnique(sorted) ? { notes: sorted, status: value.status, v: 1 } : null;
+}
+function parseHostPolicy(value) {
+  if (!structurallyBounded(value) || !isRecord(value) || !exactKeys(value, ["conflicts", "destination", "expectedSource", "review", "rights", "v"]) || value.v !== 1)
+    return null;
+  const destination = parseDestination(value.destination);
+  const expectedSource = parseExpectedSource(value.expectedSource);
+  const conflicts = parseConflicts(value.conflicts);
+  const review = parseReview(value.review);
+  const rights = destination === null ? null : parseRights(value.rights, destination.purpose);
+  return destination !== null && expectedSource !== null && conflicts !== null && review !== null && rights !== null ? immutableClone({ conflicts, destination, expectedSource, review, rights, v: 1 }) : null;
+}
+function verifyCapsule(value, expectedSource) {
+  try {
+    if (!structurallyBounded(value) || !isRecord(value) || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"]) || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots) || value.records.length < 1 || value.records.length > MAX_RECORDS || value.roots.length < 1 || value.roots.length > MAX_ROOTS || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES)
+      return null;
+    const verified = verifyOhDependencyClosureAgainstV1(value, {
+      binding: expectedSource.binding,
+      head: expectedSource.head
+    });
+    return verified.ok && verified.closure.binding.profile.profileKind === "working" ? verified.closure : null;
+  } catch {
+    return null;
+  }
 }
 function parseDisclosures(value, keys) {
   if (!Array.isArray(value) || value.length > 256)
@@ -655,39 +490,23 @@ function renderMarkdown(manifest, candidateSha256) {
 `)}
 `;
 }
-function prepareOhAdoptionCandidateV1(value) {
-  if (!isRecord(value) || !exactKeys(value, [
-    "capsule",
-    "conflicts",
-    "destination",
-    "expectedSource",
-    "redactions",
-    "review",
-    "rights",
-    "transformations",
-    "v"
-  ]) || value.v !== 1) {
-    throw new TypeError("Invalid Oh adoption candidate input.");
+function prepareWithPolicy(value, policy) {
+  if (!structurallyBounded(value) || !isRecord(value) || !exactKeys(value, ["capsule", "redactions", "transformations", "v"]) || value.v !== 1) {
+    throw new TypeError("Invalid Oh adoption preparation input.");
   }
-  const expectedSource = parseExpectedSource(value.expectedSource);
-  const capsule = parseOhDependencyClosureCapsuleV1(value.capsule, value.expectedSource);
-  const destination = parseDestination(value.destination);
-  if (expectedSource === null || capsule === null || destination === null) {
-    throw new TypeError("The source capsule or destination is invalid.");
-  }
-  const rights = parseRights(value.rights, destination.purpose);
-  const review = parseReview(value.review);
-  const conflicts = parseConflicts(value.conflicts);
+  const capsule = verifyCapsule(value.capsule, policy.expectedSource);
+  if (capsule === null)
+    throw new TypeError("The source capsule is invalid for the bound authority and head.");
   const recordKeys = new Set(capsule.records.map((record) => record.key));
   const transformations = parseDisclosures(value.transformations, recordKeys);
   const redactions = parseDisclosures(value.redactions, recordKeys);
   const roots = new Set(capsule.roots);
-  if (rights === null || review === null || conflicts === null || transformations === null || redactions === null || capsule.records.filter((record) => roots.has(record.key)).every((record) => record.kind === "view")) {
-    throw new TypeError("Adoption requires rights, review, conflict, and authoritative-root declarations.");
+  if (transformations === null || redactions === null || capsule.records.filter((record) => roots.has(record.key)).every((record) => record.kind === "view")) {
+    throw new TypeError("Adoption requires valid disclosures and an authoritative root.");
   }
   const source = {
-    authorityId: expectedSource.authorityId,
-    binding: capsule.binding,
+    authorityId: policy.expectedSource.authorityId,
+    binding: { bindingSha256: capsule.binding.bindingSha256, v: 1 },
     closureSha256: capsule.closureSha256,
     head: capsule.head,
     records: capsule.records.map((record) => ({
@@ -701,29 +520,35 @@ function prepareOhAdoptionCandidateV1(value) {
     v: 1
   };
   const manifest = {
-    conflicts,
-    destination,
+    conflicts: policy.conflicts,
+    destination: policy.destination,
     format: "hraness.kb.oh-adoption-candidate.v1",
     redactions,
-    review,
-    rights,
+    review: policy.review,
+    rights: policy.rights,
     source,
     status: "prepared",
     transformations,
     v: 1
   };
-  const candidateSha256 = digest(manifest);
+  const candidateSha256 = canonicalSha256(manifest);
   const markdown = renderMarkdown(manifest, candidateSha256);
   if (Buffer.byteLength(markdown, "utf8") > MAX_CAPSULE_BYTES) {
     throw new RangeError("The adoption candidate exceeds its Markdown byte limit.");
   }
-  return {
+  return immutableClone({
     artifactSha256: createHash("sha256").update(markdown).digest("hex"),
     candidateSha256,
     manifest,
     markdown,
     v: 1
-  };
+  });
+}
+function createOhAdoptionPreparerV1(value) {
+  const policy = parseHostPolicy(value);
+  if (policy === null)
+    throw new TypeError("Invalid Oh adoption host policy.");
+  return Object.freeze({ prepare: (input) => prepareWithPolicy(input, policy) });
 }
 export {
   workflowFromUnknown,
@@ -762,11 +587,9 @@ export {
   readVaultNotes,
   queryVault,
   qmdIndexerVersion,
-  prepareOhAdoptionCandidateV1,
   planStatuses,
   percolateVault,
   parseRetrievalEvaluationCorpus,
-  parseOhDependencyClosureCapsuleV1,
   parseNote,
   parseLocalAttachmentReferences,
   parseGitHistoryOutput,
@@ -812,6 +635,7 @@ export {
   createVerifiedEmbeddingModelLease,
   createSyntheticRankFusionFixture,
   createRepresentativeRetrievalFixture,
+  createOhAdoptionPreparerV1,
   createNote,
   createConceptNote,
   compareAgentGuideAudits,

--- a/docs/design.md
+++ b/docs/design.md
@@ -217,6 +217,25 @@ and avoids a repository-wide merge hotspot. A future cache may live outside the
 vault only if measurements justify it; it must be content-addressed by source
 and analysis version and rebuild on any mismatch.
 
+## Oh adoption stops at a review candidate
+
+`prepareOhAdoptionCandidateV1` accepts one dependency-closed capsule from an
+Oh working authority and produces deterministic Markdown for destination-owned
+review. The caller must pin the exact expected source binding and head, state
+the destination purpose and proposed `notes/` path, provide a purpose-matched
+rights decision, name the required review route, and record the conflict
+assessment and any transformations or redactions. The parser rejects a
+tampered, incomplete, over-complete, wrong-authority, or derived-only capsule.
+
+The returned status is always `prepared`. The function does not open a vault,
+write a note, invoke Git, import an operation chain or database, retain a
+projection, or write to canonical Oh. A reviewer must inspect the candidate and
+author destination Markdown through KB's existing revision-checked write path;
+the source's proposed assertion is never relabeled as reviewed knowledge. The
+temporary structural verifier is intentionally narrow and must be replaced by
+the immutable `@hraness/oh` dependency-closure verifier once version 0.2.0 is
+published and pinned.
+
 ## Catalog ownership is explicit
 
 A managed vault gives one marked region in `index.md` to the tool. `kb refresh`

--- a/docs/design.md
+++ b/docs/design.md
@@ -219,22 +219,27 @@ and analysis version and rebuild on any mismatch.
 
 ## Oh adoption stops at a review candidate
 
-`prepareOhAdoptionCandidateV1` accepts one dependency-closed capsule from an
-Oh working authority and produces deterministic Markdown for destination-owned
-review. The caller must pin the exact expected source binding and head, state
-the destination purpose and proposed `notes/` path, provide a purpose-matched
-rights decision, name the required review route, and record the conflict
-assessment and any transformations or redactions. The parser rejects a
-tampered, incomplete, over-complete, wrong-authority, or derived-only capsule.
+`createOhAdoptionPreparerV1` captures, in trusted host code, one exact Oh
+working-authority binding and head plus the destination purpose and proposed
+`notes/` path, a purpose-matched rights decision, the required review route,
+and the conflict assessment. Its returned facade accepts only an Oh dependency
+closure and explicit transformation or redaction disclosures. A model cannot
+replace the source authority, destination, rights, review, or conflict policy
+inside a preparation call.
+
+KB delegates contract, binding, head, record, and exact dependency-closure
+verification to the immutable `@hraness/oh` v0.2.0 store API. KB keeps lower
+local byte, record, root, depth, and node ceilings and rejects accessors,
+symbols, cycles, canonical-authority bindings, tampered or incomplete records,
+over-complete closures, wrong bindings or heads, and derived-only roots. The
+review artifact records the source authority and binding digest, full head,
+closure roots, and record digests without copying source realm or space IDs.
 
 The returned status is always `prepared`. The function does not open a vault,
 write a note, invoke Git, import an operation chain or database, retain a
 projection, or write to canonical Oh. A reviewer must inspect the candidate and
 author destination Markdown through KB's existing revision-checked write path;
-the source's proposed assertion is never relabeled as reviewed knowledge. The
-temporary structural verifier is intentionally narrow and must be replaced by
-the immutable `@hraness/oh` dependency-closure verifier once version 0.2.0 is
-published and pinned.
+the source's proposed assertion is never relabeled as reviewed knowledge.
 
 ## Catalog ownership is explicit
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -131,7 +131,7 @@ keep the tag and npm version immutable. After the recovery workflow is on
 current `main`, dispatch it with the existing tag:
 
 ```sh
-gh workflow run release.yml --ref main -f tag=v0.17.3
+gh workflow run release.yml --ref main -f tag=v0.18.0
 ```
 
 The recovery path accepts only the newest stable repository tag. It freshly

--- a/package.json
+++ b/package.json
@@ -335,6 +335,7 @@
     "src/init.ts",
     "src/navigation.ts",
     "src/note-lock.ts",
+    "src/oh-adoption.ts",
     "src/percolate.ts",
     "src/portfolio.ts",
     "src/portfolio-audit.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.17.3",
+  "version": "0.18.0",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {
@@ -392,6 +392,7 @@
     "prepack": "bun run check"
   },
   "dependencies": {
+    "@hraness/oh": "github:hraness/oh#v0.2.0",
     "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
     "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
     "agent-browser": "0.32.3",

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,10 +8,17 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.17.3"
+      "version": "0.18.0"
     }
   ],
   "dependencies": [
+    {
+      "from": "@hraness/kb",
+      "scope": "runtime",
+      "specifier": "github:hraness/oh#v0.2.0",
+      "to": "@hraness/oh",
+      "sourceRepository": "hraness/oh"
+    },
     {
       "from": "@hraness/kb",
       "scope": "runtime",

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -409,8 +409,8 @@ describe("canonical npm package identity", () => {
         sourcePackJson,
       });
       const verified = await verifyNpmPackageIdentity(validInput);
-      expect(verified.fileCount).toBe(200);
-      expect(verified.unpackedBytes).toBe(4_861_496);
+      expect(verified.fileCount).toBe(201);
+      expect(verified.unpackedBytes).toBe(4_909_145);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -120,7 +120,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.17.3",
+      version: "0.18.0",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",
@@ -410,7 +410,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(201);
-      expect(verified.unpackedBytes).toBe(4_909_145);
+      expect(verified.unpackedBytes).toBe(4_894_547);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -410,7 +410,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(201);
-      expect(verified.unpackedBytes).toBe(4_894_547);
+      expect(verified.unpackedBytes).toBe(4_895_276);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -31,7 +31,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.17.3
+  bun add --global @hraness/kb@0.18.0
 }
 kb --help
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./git.js";
 export * from "./graph.js";
 export * from "./init.js";
 export * from "./navigation.js";
+export * from "./oh-adoption.js";
 export * from "./percolate.js";
 export * from "./query.js";
 export * from "./repository-memory.js";

--- a/src/oh-adoption.test.ts
+++ b/src/oh-adoption.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+import {
+  parseOhDependencyClosureCapsuleV1,
+  prepareOhAdoptionCandidateV1,
+} from "./oh-adoption.js";
+
+function canonical(value: unknown): string {
+  if (value === null || typeof value === "boolean" || typeof value === "string" || typeof value === "number") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`;
+}
+
+function sha(value: unknown): string {
+  return createHash("sha256").update(canonical(value)).digest("hex");
+}
+
+function fixture(kind = "assertion") {
+  const capabilities = { changesSince: true, dependencyClosureExport: true, exactSnapshots: true,
+    operationReplication: false, semanticBundleCommit: true, v: 1, wholeSpacePurge: true } as const;
+  const profilePayload = { applicationProfileSha256: null, capabilities, profileId: "kb.working.v1",
+    profileKind: "working", v: 1 } as const;
+  const profile = { ...profilePayload, profileSha256: sha(profilePayload) };
+  const bindingPayload = { contractSha256: "a".repeat(64), profile, realmId: "tenant:test/thread:one",
+    spaceId: "thread:one", v: 1 } as const;
+  const binding = { ...bindingPayload, bindingSha256: sha(bindingPayload) };
+  const evidencePayload = { dependencies: [], key: "evidence:source", kind: "evidence", v: 1,
+    value: { locator: "https://example.test/source" } } as const;
+  const evidence = { ...evidencePayload, recordSha256: sha(evidencePayload) };
+  const assertionPayload = { dependencies: ["evidence:source"], key: "assertion:candidate", kind, v: 1,
+    value: { state: "proposed", text: "A bounded candidate." } } as const;
+  const assertion = { ...assertionPayload, recordSha256: sha(assertionPayload) };
+  const records = [assertion, evidence];
+  const recordRefs = records.map((record) => ({ dependencies: record.dependencies, key: record.key,
+    kind: record.kind, sha256: record.recordSha256, v: 1 }));
+  const head = { generation: 3, graphRevisionSha256: "b".repeat(64), operationSha256: "c".repeat(64),
+    recordsSha256: sha(recordRefs), sequence: 3, v: 1 } as const;
+  const capsulePayload = { binding, head, records, roots: ["assertion:candidate"], v: 1 } as const;
+  const capsule = { ...capsulePayload, closureSha256: sha(capsulePayload) };
+  const expectedSource = { authorityId: "sponge.working.primary", binding, head, v: 1 } as const;
+  const input = {
+    capsule,
+    conflicts: { notes: ["No destination collision was found; review must confirm."],
+      status: "none-observed", v: 1 },
+    destination: { purpose: "kb.maintained-knowledge", targetPath: "notes/adopted-candidate.md", v: 1 },
+    expectedSource,
+    redactions: [],
+    review: { route: "kb.adoption-review", status: "required", v: 1 },
+    rights: { decisionId: "rights:decision-one", disposition: "cleared-for-purpose",
+      purpose: "kb.maintained-knowledge", v: 1 },
+    transformations: [{ id: "transform:normalize-title", recordKey: "assertion:candidate",
+      summary: "Normalize the title without changing the proposed claim.", v: 1 }],
+    v: 1,
+  } as const;
+  return { assertion, binding, capsule, evidence, expectedSource, head, input };
+}
+
+describe("Oh dependency-closure adoption", () => {
+  test("prepares deterministic review-only Markdown without laundering proposal authority", () => {
+    const { input } = fixture();
+    const first = prepareOhAdoptionCandidateV1(input);
+    const second = prepareOhAdoptionCandidateV1({ ...input,
+      transformations: [...input.transformations].reverse() });
+    expect(second).toEqual(first);
+    expect(first.manifest.status).toBe("prepared");
+    expect(first.manifest.review.status).toBe("required");
+    expect(first.markdown).toContain("This is a review candidate, not reviewed knowledge.");
+    expect(first.markdown).toContain("does not mutate a vault");
+    expect(first.markdown).not.toContain("status: reviewed");
+    expect(first.artifactSha256).toBe(createHash("sha256").update(first.markdown).digest("hex"));
+    expect(Object.keys(first)).toEqual(["artifactSha256", "candidateSha256", "manifest", "markdown", "v"]);
+  });
+
+  test("verifies the exact expected binding and head and rejects closure tampering", () => {
+    const { assertion, capsule, evidence, expectedSource, head } = fixture();
+    expect(parseOhDependencyClosureCapsuleV1(capsule, expectedSource)).toEqual(capsule);
+    expect(parseOhDependencyClosureCapsuleV1(capsule, { ...expectedSource,
+      head: { ...head, operationSha256: "d".repeat(64) } })).toBeNull();
+    expect(parseOhDependencyClosureCapsuleV1(capsule, { ...expectedSource,
+      binding: { ...expectedSource.binding, bindingSha256: "e".repeat(64) } })).toBeNull();
+    expect(parseOhDependencyClosureCapsuleV1({ ...capsule,
+      records: [{ ...assertion, value: { state: "reviewed", text: "Tampered." } }, evidence] }, expectedSource)).toBeNull();
+    expect(parseOhDependencyClosureCapsuleV1({ ...capsule, records: [assertion] }, expectedSource)).toBeNull();
+    const extraPayload = { dependencies: [], key: "entity:smuggled", kind: "entity", v: 1,
+      value: { name: "Smuggled" } } as const;
+    const extra = { ...extraPayload, recordSha256: sha(extraPayload) };
+    const extraCapsulePayload = { binding: capsule.binding, head: capsule.head,
+      records: [...capsule.records, extra].sort((left, right) => left.key.localeCompare(right.key)),
+      roots: capsule.roots, v: 1 } as const;
+    expect(parseOhDependencyClosureCapsuleV1({ ...extraCapsulePayload,
+      closureSha256: sha(extraCapsulePayload) }, expectedSource)).toBeNull();
+  });
+
+  test("fails closed on unsafe targets, missing policy, derived-only roots, and projection-shaped inputs", () => {
+    const { capsule, expectedSource, input } = fixture();
+    for (const targetPath of ["../notes/out.md", "/tmp/out.md", "notes/../../out.md", "plans/out.md", "notes/out.txt"]) {
+      expect(() => prepareOhAdoptionCandidateV1({ ...input,
+        destination: { ...input.destination, targetPath } })).toThrow("source capsule or destination");
+    }
+    const { rights: _rights, ...withoutRights } = input;
+    expect(() => prepareOhAdoptionCandidateV1(withoutRights)).toThrow("Invalid Oh adoption");
+    expect(() => prepareOhAdoptionCandidateV1({ ...input,
+      review: { route: "kb.adoption-review", status: "reviewed", v: 1 } })).toThrow("requires rights");
+    const derived = fixture("view");
+    expect(() => prepareOhAdoptionCandidateV1(derived.input)).toThrow("authoritative-root");
+    expect(parseOhDependencyClosureCapsuleV1({ authority: "derived", rows: [], v: 1 }, expectedSource)).toBeNull();
+    expect(parseOhDependencyClosureCapsuleV1({ ...capsule, projection: { rows: [] } }, expectedSource)).toBeNull();
+  });
+
+  test("requires disclosures to reference exact capsule records and escapes review prose", () => {
+    const { input } = fixture();
+    expect(() => prepareOhAdoptionCandidateV1({ ...input,
+      redactions: [{ id: "redact:one", recordKey: "entity:outside", summary: "Remove", v: 1 }] }))
+      .toThrow("requires rights");
+    const candidate = prepareOhAdoptionCandidateV1({ ...input,
+      conflicts: { notes: ["<script>alert(1)</script>"], status: "requires-resolution", v: 1 } });
+    expect(candidate.markdown).not.toContain("<script>");
+    expect(candidate.markdown).toContain("\\<script\\>");
+  });
+
+  test("rejects accessors and non-JSON properties without invoking foreign code", () => {
+    const { expectedSource, input } = fixture();
+    let invoked = false;
+    const hostile = { ...input.capsule } as Record<string, unknown>;
+    Object.defineProperty(hostile, "records", { enumerable: true, get: () => {
+      invoked = true;
+      return input.capsule.records;
+    } });
+    expect(parseOhDependencyClosureCapsuleV1(hostile, expectedSource)).toBeNull();
+    expect(invoked).toBeFalse();
+    expect(parseOhDependencyClosureCapsuleV1({ ...input.capsule,
+      [Symbol("smuggled")]: true }, expectedSource)).toBeNull();
+  });
+});

--- a/src/oh-adoption.test.ts
+++ b/src/oh-adoption.test.ts
@@ -209,6 +209,37 @@ describe("Oh dependency-closure adoption", () => {
     expect(candidate.markdown).toContain("\\<script\\>");
   });
 
+  test("rejects terminal, bidi, and Unicode line controls from every review disclosure", () => {
+    const { hostPolicy, prepareInput } = fixture();
+    const unsafeCodePoints = [
+      ...Array.from({ length: 0x20 }, (_, index) => index),
+      ...Array.from({ length: 0x9f - 0x7f + 1 }, (_, index) => 0x7f + index),
+      0x061c,
+      0x200e,
+      0x200f,
+      ...Array.from({ length: 0x202e - 0x2028 + 1 }, (_, index) => 0x2028 + index),
+      ...Array.from({ length: 0x2069 - 0x2066 + 1 }, (_, index) => 0x2066 + index),
+      0xfeff,
+    ];
+    for (const codePoint of unsafeCodePoints) {
+      const character = String.fromCodePoint(codePoint);
+      expect(() => createOhAdoptionPreparerV1({
+        ...hostPolicy,
+        conflicts: {
+          ...hostPolicy.conflicts,
+          notes: [`No conflict ${character}confirmed.`],
+        },
+      })).toThrow("host policy");
+      expect(() => createOhAdoptionPreparerV1(hostPolicy).prepare({
+        ...prepareInput,
+        transformations: [{
+          ...prepareInput.transformations[0]!,
+          summary: `Approved ${character}txt.exe`,
+        }],
+      })).toThrow("valid disclosures");
+    }
+  });
+
   test("rejects accessors, symbols, oversized capsules, and deep input without invoking code", () => {
     const { capsule, hostPolicy, prepareInput } = fixture();
     const preparer = createOhAdoptionPreparerV1(hostPolicy);

--- a/src/oh-adoption.test.ts
+++ b/src/oh-adoption.test.ts
@@ -2,69 +2,103 @@ import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 
 import {
-  parseOhDependencyClosureCapsuleV1,
-  prepareOhAdoptionCandidateV1,
-} from "./oh-adoption.js";
+  canonicalSha256,
+  createKnowledgeGraphRecordV1,
+  knowledgeGraphRecordRefV1,
+  type KnowledgeGraphRecordKindV1,
+} from "@hraness/oh";
+import {
+  createOhDependencyClosureV1,
+  createOhStoreBindingV1,
+  OH_CANONICAL_STORE_PROFILE_V1,
+  OH_WORKING_STORE_PROFILE_V1,
+} from "@hraness/oh/store";
 
-function canonical(value: unknown): string {
-  if (value === null || typeof value === "boolean" || typeof value === "string" || typeof value === "number") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`).join(",")}}`;
-}
+import { createOhAdoptionPreparerV1 } from "./oh-adoption.js";
 
-function sha(value: unknown): string {
-  return createHash("sha256").update(canonical(value)).digest("hex");
-}
-
-function fixture(kind = "assertion") {
-  const capabilities = { changesSince: true, dependencyClosureExport: true, exactSnapshots: true,
-    operationReplication: false, semanticBundleCommit: true, v: 1, wholeSpacePurge: true } as const;
-  const profilePayload = { applicationProfileSha256: null, capabilities, profileId: "kb.working.v1",
-    profileKind: "working", v: 1 } as const;
-  const profile = { ...profilePayload, profileSha256: sha(profilePayload) };
-  const bindingPayload = { contractSha256: "a".repeat(64), profile, realmId: "tenant:test/thread:one",
-    spaceId: "thread:one", v: 1 } as const;
-  const binding = { ...bindingPayload, bindingSha256: sha(bindingPayload) };
-  const evidencePayload = { dependencies: [], key: "evidence:source", kind: "evidence", v: 1,
-    value: { locator: "https://example.test/source" } } as const;
-  const evidence = { ...evidencePayload, recordSha256: sha(evidencePayload) };
-  const assertionPayload = { dependencies: ["evidence:source"], key: "assertion:candidate", kind, v: 1,
-    value: { state: "proposed", text: "A bounded candidate." } } as const;
-  const assertion = { ...assertionPayload, recordSha256: sha(assertionPayload) };
+function fixture(kind: KnowledgeGraphRecordKindV1 = "assertion") {
+  const binding = createOhStoreBindingV1({
+    profile: OH_WORKING_STORE_PROFILE_V1,
+    realmId: "tenant:test/thread:one",
+    spaceId: "thread:one",
+    v: 1,
+  });
+  const evidence = createKnowledgeGraphRecordV1({
+    dependencies: [],
+    key: "evidence:source",
+    kind: "evidence",
+    v: 1,
+    value: { locator: "https://example.test/source" },
+  });
+  const assertion = createKnowledgeGraphRecordV1({
+    dependencies: ["evidence:source"],
+    key: "assertion:candidate",
+    kind,
+    v: 1,
+    value: { state: "proposed", text: "A bounded candidate." },
+  });
   const records = [assertion, evidence];
-  const recordRefs = records.map((record) => ({ dependencies: record.dependencies, key: record.key,
-    kind: record.kind, sha256: record.recordSha256, v: 1 }));
-  const head = { generation: 3, graphRevisionSha256: "b".repeat(64), operationSha256: "c".repeat(64),
-    recordsSha256: sha(recordRefs), sequence: 3, v: 1 } as const;
-  const capsulePayload = { binding, head, records, roots: ["assertion:candidate"], v: 1 } as const;
-  const capsule = { ...capsulePayload, closureSha256: sha(capsulePayload) };
-  const expectedSource = { authorityId: "sponge.working.primary", binding, head, v: 1 } as const;
-  const input = {
-    capsule,
-    conflicts: { notes: ["No destination collision was found; review must confirm."],
-      status: "none-observed", v: 1 },
-    destination: { purpose: "kb.maintained-knowledge", targetPath: "notes/adopted-candidate.md", v: 1 },
-    expectedSource,
-    redactions: [],
-    review: { route: "kb.adoption-review", status: "required", v: 1 },
-    rights: { decisionId: "rights:decision-one", disposition: "cleared-for-purpose",
-      purpose: "kb.maintained-knowledge", v: 1 },
-    transformations: [{ id: "transform:normalize-title", recordKey: "assertion:candidate",
-      summary: "Normalize the title without changing the proposed claim.", v: 1 }],
+  const head = {
+    generation: 3,
+    graphRevisionSha256: canonicalSha256({ fixture: "graph-revision", v: 1 }),
+    operationSha256: canonicalSha256({ fixture: "operation", v: 1 }),
+    recordsSha256: canonicalSha256(records.map(knowledgeGraphRecordRefV1)),
+    sequence: 3,
     v: 1,
   } as const;
-  return { assertion, binding, capsule, evidence, expectedSource, head, input };
+  const capsule = createOhDependencyClosureV1({
+    binding,
+    roots: [assertion.key],
+    snapshot: { head, records, v: 1 },
+  });
+  const expectedSource = {
+    authorityId: "sponge.working.primary",
+    binding,
+    head,
+    v: 1,
+  } as const;
+  const hostPolicy = {
+    conflicts: {
+      notes: ["No destination collision was found; review must confirm."],
+      status: "none-observed",
+      v: 1,
+    },
+    destination: {
+      purpose: "kb.maintained-knowledge",
+      targetPath: "notes/adopted-candidate.md",
+      v: 1,
+    },
+    expectedSource,
+    review: { route: "kb.adoption-review", status: "required", v: 1 },
+    rights: {
+      decisionId: "rights:decision-one",
+      disposition: "cleared-for-purpose",
+      purpose: "kb.maintained-knowledge",
+      v: 1,
+    },
+    v: 1,
+  } as const;
+  const prepareInput = {
+    capsule,
+    redactions: [],
+    transformations: [{
+      id: "transform:normalize-title",
+      recordKey: assertion.key,
+      summary: "Normalize the title without changing the proposed claim.",
+      v: 1,
+    }],
+    v: 1,
+  } as const;
+  return { assertion, binding, capsule, evidence, expectedSource, head, hostPolicy, prepareInput };
 }
 
 describe("Oh dependency-closure adoption", () => {
-  test("prepares deterministic review-only Markdown without laundering proposal authority", () => {
-    const { input } = fixture();
-    const first = prepareOhAdoptionCandidateV1(input);
-    const second = prepareOhAdoptionCandidateV1({ ...input,
-      transformations: [...input.transformations].reverse() });
+  test("prepares deterministic immutable review bytes from a host-bound policy", () => {
+    const { hostPolicy, prepareInput } = fixture();
+    const preparer = createOhAdoptionPreparerV1(hostPolicy);
+    const first = preparer.prepare(prepareInput);
+    const second = preparer.prepare({ ...prepareInput,
+      transformations: [...prepareInput.transformations].reverse() });
     expect(second).toEqual(first);
     expect(first.manifest.status).toBe("prepared");
     expect(first.manifest.review.status).toBe("required");
@@ -73,66 +107,144 @@ describe("Oh dependency-closure adoption", () => {
     expect(first.markdown).not.toContain("status: reviewed");
     expect(first.artifactSha256).toBe(createHash("sha256").update(first.markdown).digest("hex"));
     expect(Object.keys(first)).toEqual(["artifactSha256", "candidateSha256", "manifest", "markdown", "v"]);
+    expect(Object.keys(first.manifest.source.binding)).toEqual(["bindingSha256", "v"]);
+    expect("realmId" in first.manifest.source.binding).toBeFalse();
+    expect(Object.isFrozen(first)).toBeTrue();
+    expect(Object.isFrozen(first.manifest)).toBeTrue();
+    expect(Object.isFrozen(first.manifest.source.head)).toBeTrue();
+    expect(Object.isFrozen(first.manifest.source.records)).toBeTrue();
+    expect(Object.isFrozen(first.manifest.source.records[0]!.dependencies)).toBeTrue();
   });
 
-  test("verifies the exact expected binding and head and rejects closure tampering", () => {
-    const { assertion, capsule, evidence, expectedSource, head } = fixture();
-    expect(parseOhDependencyClosureCapsuleV1(capsule, expectedSource)).toEqual(capsule);
-    expect(parseOhDependencyClosureCapsuleV1(capsule, { ...expectedSource,
-      head: { ...head, operationSha256: "d".repeat(64) } })).toBeNull();
-    expect(parseOhDependencyClosureCapsuleV1(capsule, { ...expectedSource,
-      binding: { ...expectedSource.binding, bindingSha256: "e".repeat(64) } })).toBeNull();
-    expect(parseOhDependencyClosureCapsuleV1({ ...capsule,
-      records: [{ ...assertion, value: { state: "reviewed", text: "Tampered." } }, evidence] }, expectedSource)).toBeNull();
-    expect(parseOhDependencyClosureCapsuleV1({ ...capsule, records: [assertion] }, expectedSource)).toBeNull();
-    const extraPayload = { dependencies: [], key: "entity:smuggled", kind: "entity", v: 1,
-      value: { name: "Smuggled" } } as const;
-    const extra = { ...extraPayload, recordSha256: sha(extraPayload) };
-    const extraCapsulePayload = { binding: capsule.binding, head: capsule.head,
-      records: [...capsule.records, extra].sort((left, right) => left.key.localeCompare(right.key)),
-      roots: capsule.roots, v: 1 } as const;
-    expect(parseOhDependencyClosureCapsuleV1({ ...extraCapsulePayload,
-      closureSha256: sha(extraCapsulePayload) }, expectedSource)).toBeNull();
-  });
-
-  test("fails closed on unsafe targets, missing policy, derived-only roots, and projection-shaped inputs", () => {
-    const { capsule, expectedSource, input } = fixture();
-    for (const targetPath of ["../notes/out.md", "/tmp/out.md", "notes/../../out.md", "plans/out.md", "notes/out.txt"]) {
-      expect(() => prepareOhAdoptionCandidateV1({ ...input,
-        destination: { ...input.destination, targetPath } })).toThrow("source capsule or destination");
+  test("binds authority and policy before exposing the narrow preparation facade", () => {
+    const { hostPolicy, prepareInput } = fixture();
+    const mutablePolicy = structuredClone(hostPolicy);
+    const preparer = createOhAdoptionPreparerV1(mutablePolicy);
+    Reflect.set(mutablePolicy.destination, "targetPath", "notes/laundered.md");
+    Reflect.set(mutablePolicy.expectedSource, "authorityId", "attacker.working");
+    Reflect.set(mutablePolicy.conflicts.notes, "0", "Silently replace the destination.");
+    const candidate = preparer.prepare(prepareInput);
+    expect(candidate.manifest.destination.targetPath).toBe("notes/adopted-candidate.md");
+    expect(candidate.manifest.source.authorityId).toBe("sponge.working.primary");
+    expect(candidate.manifest.conflicts.notes).toEqual([
+      "No destination collision was found; review must confirm.",
+    ]);
+    expect(Object.keys(preparer)).toEqual(["prepare"]);
+    for (const forbidden of ["commit", "purge", "store", "write", "expectedSource", "destination"]) {
+      expect(forbidden in preparer).toBeFalse();
     }
-    const { rights: _rights, ...withoutRights } = input;
-    expect(() => prepareOhAdoptionCandidateV1(withoutRights)).toThrow("Invalid Oh adoption");
-    expect(() => prepareOhAdoptionCandidateV1({ ...input,
-      review: { route: "kb.adoption-review", status: "reviewed", v: 1 } })).toThrow("requires rights");
-    const derived = fixture("view");
-    expect(() => prepareOhAdoptionCandidateV1(derived.input)).toThrow("authoritative-root");
-    expect(parseOhDependencyClosureCapsuleV1({ authority: "derived", rows: [], v: 1 }, expectedSource)).toBeNull();
-    expect(parseOhDependencyClosureCapsuleV1({ ...capsule, projection: { rows: [] } }, expectedSource)).toBeNull();
+    expect(() => preparer.prepare({ ...prepareInput,
+      destination: hostPolicy.destination })).toThrow("Invalid Oh adoption preparation input");
+    expect(() => preparer.prepare({ ...prepareInput,
+      expectedSource: hostPolicy.expectedSource })).toThrow("Invalid Oh adoption preparation input");
   });
 
-  test("requires disclosures to reference exact capsule records and escapes review prose", () => {
-    const { input } = fixture();
-    expect(() => prepareOhAdoptionCandidateV1({ ...input,
+  test("uses Oh's verifier for exact binding, head, closure, and records", () => {
+    const { assertion, binding, capsule, evidence, head, hostPolicy, prepareInput } = fixture();
+    const wrongHead = createOhAdoptionPreparerV1({ ...hostPolicy,
+      expectedSource: { ...hostPolicy.expectedSource,
+        head: { ...head, operationSha256: canonicalSha256({ wrong: "head" }) } } });
+    expect(() => wrongHead.prepare(prepareInput)).toThrow("bound authority and head");
+
+    const otherBinding = createOhStoreBindingV1({ profile: OH_WORKING_STORE_PROFILE_V1,
+      realmId: "tenant:test/thread:other", spaceId: "thread:other", v: 1 });
+    const wrongBinding = createOhAdoptionPreparerV1({ ...hostPolicy,
+      expectedSource: { ...hostPolicy.expectedSource, binding: otherBinding } });
+    expect(() => wrongBinding.prepare(prepareInput)).toThrow("bound authority and head");
+
+    const preparer = createOhAdoptionPreparerV1(hostPolicy);
+    expect(() => preparer.prepare({ ...prepareInput, capsule: { ...capsule,
+      records: [{ ...assertion, value: { state: "reviewed", text: "Tampered." } }, evidence] } }))
+      .toThrow("source capsule");
+    expect(() => preparer.prepare({ ...prepareInput,
+      capsule: { ...capsule, records: [assertion] } })).toThrow("source capsule");
+
+    const extra = createKnowledgeGraphRecordV1({ dependencies: [], key: "entity:smuggled",
+      kind: "entity", v: 1, value: { name: "Smuggled" } });
+    const extraPayload = { binding, head,
+      records: [...capsule.records, extra].sort((left, right) => left.key.localeCompare(right.key)),
+      roots: capsule.roots, v: 1 as const };
+    expect(() => preparer.prepare({ ...prepareInput, capsule: { ...extraPayload,
+      closureSha256: canonicalSha256(extraPayload) } })).toThrow("source capsule");
+  });
+
+  test("fails closed on unsafe host policy, canonical sources, and derived-only roots", () => {
+    const { head, hostPolicy } = fixture();
+    for (const targetPath of ["../notes/out.md", "/tmp/out.md", "notes/../../out.md",
+      "plans/out.md", "notes/out.txt", "notes/.hidden.md"]) {
+      expect(() => createOhAdoptionPreparerV1({ ...hostPolicy,
+        destination: { ...hostPolicy.destination, targetPath } })).toThrow("host policy");
+    }
+    const { rights: _rights, ...withoutRights } = hostPolicy;
+    expect(() => createOhAdoptionPreparerV1(withoutRights)).toThrow("host policy");
+    expect(() => createOhAdoptionPreparerV1({ ...hostPolicy,
+      review: { route: "kb.adoption-review", status: "reviewed", v: 1 } })).toThrow("host policy");
+    expect(() => createOhAdoptionPreparerV1({ ...hostPolicy,
+      rights: { ...hostPolicy.rights, purpose: "kb.some-other-purpose" } })).toThrow("host policy");
+
+    const canonicalBinding = createOhStoreBindingV1({ profile: OH_CANONICAL_STORE_PROFILE_V1,
+      realmId: "tenant:test/canonical", spaceId: "canonical", v: 1 });
+    expect(() => createOhAdoptionPreparerV1({ ...hostPolicy,
+      expectedSource: { ...hostPolicy.expectedSource, binding: canonicalBinding, head } }))
+      .toThrow("host policy");
+
+    const derived = fixture("view");
+    expect(() => createOhAdoptionPreparerV1(derived.hostPolicy).prepare(derived.prepareInput))
+      .toThrow("authoritative root");
+    expect(() => createOhAdoptionPreparerV1(hostPolicy).prepare({
+      authority: "derived", rows: [], v: 1,
+    })).toThrow("preparation input");
+  });
+
+  test("requires exact record disclosures and escapes host review prose", () => {
+    const { hostPolicy, prepareInput } = fixture();
+    const preparer = createOhAdoptionPreparerV1(hostPolicy);
+    expect(() => preparer.prepare({ ...prepareInput,
       redactions: [{ id: "redact:one", recordKey: "entity:outside", summary: "Remove", v: 1 }] }))
-      .toThrow("requires rights");
-    const candidate = prepareOhAdoptionCandidateV1({ ...input,
-      conflicts: { notes: ["<script>alert(1)</script>"], status: "requires-resolution", v: 1 } });
+      .toThrow("valid disclosures");
+    const candidate = createOhAdoptionPreparerV1({ ...hostPolicy,
+      conflicts: { notes: ["<script>alert(1)</script>"], status: "requires-resolution", v: 1 } })
+      .prepare(prepareInput);
     expect(candidate.markdown).not.toContain("<script>");
     expect(candidate.markdown).toContain("\\<script\\>");
   });
 
-  test("rejects accessors and non-JSON properties without invoking foreign code", () => {
-    const { expectedSource, input } = fixture();
+  test("rejects accessors, symbols, oversized capsules, and deep input without invoking code", () => {
+    const { capsule, hostPolicy, prepareInput } = fixture();
+    const preparer = createOhAdoptionPreparerV1(hostPolicy);
     let invoked = false;
-    const hostile = { ...input.capsule } as Record<string, unknown>;
-    Object.defineProperty(hostile, "records", { enumerable: true, get: () => {
+    const hostileCapsule = { ...capsule } as Record<string, unknown>;
+    Object.defineProperty(hostileCapsule, "records", { enumerable: true, get: () => {
       invoked = true;
-      return input.capsule.records;
+      return capsule.records;
     } });
-    expect(parseOhDependencyClosureCapsuleV1(hostile, expectedSource)).toBeNull();
+    expect(() => preparer.prepare({ ...prepareInput, capsule: hostileCapsule })).toThrow("preparation input");
     expect(invoked).toBeFalse();
-    expect(parseOhDependencyClosureCapsuleV1({ ...input.capsule,
-      [Symbol("smuggled")]: true }, expectedSource)).toBeNull();
+    expect(() => preparer.prepare({ ...prepareInput,
+      [Symbol("smuggled")]: true })).toThrow("preparation input");
+    expect(() => preparer.prepare({ ...prepareInput,
+      capsule: { ...capsule, records: Array.from({ length: 1_025 }, () => capsule.records[0]) } }))
+      .toThrow("preparation input");
+
+    let deep: unknown = "leaf";
+    for (let index = 0; index < 130; index += 1) deep = { next: deep };
+    expect(() => preparer.prepare({ ...prepareInput, redactions: deep })).toThrow("preparation input");
+
+    const hostilePolicy = { ...hostPolicy } as Record<string, unknown>;
+    Object.defineProperty(hostilePolicy, "rights", { enumerable: true, get: () => {
+      invoked = true;
+      return hostPolicy.rights;
+    } });
+    expect(() => createOhAdoptionPreparerV1(hostilePolicy)).toThrow("host policy");
+    expect(invoked).toBeFalse();
+  });
+
+  test("detaches candidate provenance from mutable capsule-owned arrays", () => {
+    const { capsule, hostPolicy, prepareInput } = fixture();
+    const candidate = createOhAdoptionPreparerV1(hostPolicy).prepare(prepareInput);
+    const original = candidate.manifest.source.records[0]!.dependencies;
+    (capsule.records[0]!.dependencies as string[]).push("entity:late-mutation");
+    expect(candidate.manifest.source.records[0]!.dependencies).toEqual(original);
+    expect(candidate.manifest.source.records[0]!.dependencies).not.toContain("entity:late-mutation");
   });
 });

--- a/src/oh-adoption.ts
+++ b/src/oh-adoption.ts
@@ -1,88 +1,77 @@
 import { createHash } from "node:crypto";
 import { posix } from "node:path";
 
-type JsonPrimitive = boolean | null | number | string;
-export type OhAdoptionJsonValue =
-  | JsonPrimitive
-  | readonly OhAdoptionJsonValue[]
-  | Readonly<{ [key: string]: OhAdoptionJsonValue }>;
+import { canonicalJson, canonicalSha256 } from "@hraness/oh";
+import {
+  parseOhHeadV1,
+  parseOhStoreBindingV1,
+  verifyOhDependencyClosureAgainstV1,
+  type OhDependencyClosureV1,
+  type OhHeadV1,
+  type OhStoreBindingV1,
+} from "@hraness/oh/store";
 
-const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
 const CODE_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
 const RECORD_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
 const MAX_CAPSULE_BYTES = 16 * 1024 * 1024;
 const MAX_RECORDS = 1_024;
 const MAX_ROOTS = 256;
-const MAX_RECORD_BYTES = 1024 * 1024;
-const MAX_DEPENDENCIES = 4_096;
 const MAX_TEXT_BYTES = 4_096;
 const MAX_STRUCTURAL_NODES = 262_144;
 const MAX_STRUCTURAL_DEPTH = 128;
 
-const OH_RECORD_KINDS = new Set([
-  "activity", "assertion", "context", "dependency-manifest", "edition", "entity",
-  "evidence", "identity-operation", "inquiry", "inquiry-event", "review-decision",
-  "rights-decision", "schema", "shape", "statement", "type-membership", "view",
-  "vocabulary",
-]);
-
-export interface OhAdoptionStoreProfileV1 {
-  readonly applicationProfileSha256: string | null;
-  readonly capabilities: Readonly<{
-    readonly changesSince: true;
-    readonly dependencyClosureExport: true;
-    readonly exactSnapshots: true;
-    readonly operationReplication: false;
-    readonly semanticBundleCommit: true;
-    readonly v: 1;
-    readonly wholeSpacePurge: true;
-  }>;
-  readonly profileId: string;
-  readonly profileKind: "working";
-  readonly profileSha256: string;
-  readonly v: 1;
-}
-
-export interface OhAdoptionStoreBindingV1 {
-  readonly bindingSha256: string;
-  readonly contractSha256: string;
-  readonly profile: OhAdoptionStoreProfileV1;
-  readonly realmId: string;
-  readonly spaceId: string;
-  readonly v: 1;
-}
-
-export interface OhAdoptionHeadV1 {
-  readonly generation: number;
-  readonly graphRevisionSha256: string | null;
-  readonly operationSha256: string | null;
-  readonly recordsSha256: string;
-  readonly sequence: number;
-  readonly v: 1;
-}
-
-export interface OhAdoptionRecordV1 {
-  readonly dependencies: readonly string[];
-  readonly key: string;
-  readonly kind: string;
-  readonly recordSha256: string;
-  readonly v: 1;
-  readonly value: OhAdoptionJsonValue;
-}
-
-export interface OhDependencyClosureCapsuleV1 {
-  readonly binding: OhAdoptionStoreBindingV1;
-  readonly closureSha256: string;
-  readonly head: OhAdoptionHeadV1;
-  readonly records: readonly OhAdoptionRecordV1[];
-  readonly roots: readonly string[];
-  readonly v: 1;
-}
-
 export interface OhAdoptionExpectedSourceV1 {
   readonly authorityId: string;
-  readonly binding: OhAdoptionStoreBindingV1;
-  readonly head: OhAdoptionHeadV1;
+  readonly binding: OhStoreBindingV1;
+  readonly head: OhHeadV1;
+  readonly v: 1;
+}
+
+export interface OhAdoptionDestinationV1 {
+  readonly purpose: string;
+  readonly targetPath: string;
+  readonly v: 1;
+}
+
+export interface OhAdoptionRightsClearanceV1 {
+  readonly decisionId: string;
+  readonly disposition: "cleared-for-purpose";
+  readonly purpose: string;
+  readonly v: 1;
+}
+
+export interface OhAdoptionReviewRequirementV1 {
+  readonly route: string;
+  readonly status: "required";
+  readonly v: 1;
+}
+
+export interface OhAdoptionConflictReviewV1 {
+  readonly notes: readonly string[];
+  readonly status: "none-observed" | "requires-resolution";
+  readonly v: 1;
+}
+
+export interface OhAdoptionChangeDisclosureV1 {
+  readonly id: string;
+  readonly recordKey: string;
+  readonly summary: string;
+  readonly v: 1;
+}
+
+export interface OhAdoptionHostPolicyV1 {
+  readonly conflicts: OhAdoptionConflictReviewV1;
+  readonly destination: OhAdoptionDestinationV1;
+  readonly expectedSource: OhAdoptionExpectedSourceV1;
+  readonly review: OhAdoptionReviewRequirementV1;
+  readonly rights: OhAdoptionRightsClearanceV1;
+  readonly v: 1;
+}
+
+export interface OhAdoptionPrepareInputV1 {
+  readonly capsule: OhDependencyClosureV1;
+  readonly redactions: readonly OhAdoptionChangeDisclosureV1[];
+  readonly transformations: readonly OhAdoptionChangeDisclosureV1[];
   readonly v: 1;
 }
 
@@ -90,17 +79,20 @@ export interface OhAdoptionCandidateV1 {
   readonly artifactSha256: string;
   readonly candidateSha256: string;
   readonly manifest: Readonly<{
-    readonly conflicts: ConflictReviewV1;
-    readonly destination: DestinationV1;
+    readonly conflicts: OhAdoptionConflictReviewV1;
+    readonly destination: OhAdoptionDestinationV1;
     readonly format: "hraness.kb.oh-adoption-candidate.v1";
-    readonly redactions: readonly ChangeDisclosureV1[];
-    readonly review: ReviewRequirementV1;
-    readonly rights: RightsClearanceV1;
+    readonly redactions: readonly OhAdoptionChangeDisclosureV1[];
+    readonly review: OhAdoptionReviewRequirementV1;
+    readonly rights: OhAdoptionRightsClearanceV1;
     readonly source: Readonly<{
       readonly authorityId: string;
-      readonly binding: OhAdoptionStoreBindingV1;
+      readonly binding: Readonly<{
+        readonly bindingSha256: string;
+        readonly v: 1;
+      }>;
       readonly closureSha256: string;
-      readonly head: OhAdoptionHeadV1;
+      readonly head: OhHeadV1;
       readonly records: readonly Readonly<{
         readonly dependencies: readonly string[];
         readonly key: string;
@@ -112,43 +104,16 @@ export interface OhAdoptionCandidateV1 {
       readonly v: 1;
     }>;
     readonly status: "prepared";
-    readonly transformations: readonly ChangeDisclosureV1[];
+    readonly transformations: readonly OhAdoptionChangeDisclosureV1[];
     readonly v: 1;
   }>;
   readonly markdown: string;
   readonly v: 1;
 }
 
-interface DestinationV1 {
-  readonly purpose: string;
-  readonly targetPath: string;
-  readonly v: 1;
-}
-
-interface RightsClearanceV1 {
-  readonly decisionId: string;
-  readonly disposition: "cleared-for-purpose";
-  readonly purpose: string;
-  readonly v: 1;
-}
-
-interface ReviewRequirementV1 {
-  readonly route: string;
-  readonly status: "required";
-  readonly v: 1;
-}
-
-interface ConflictReviewV1 {
-  readonly notes: readonly string[];
-  readonly status: "none-observed" | "requires-resolution";
-  readonly v: 1;
-}
-
-interface ChangeDisclosureV1 {
-  readonly id: string;
-  readonly recordKey: string;
-  readonly summary: string;
-  readonly v: 1;
+export interface OhAdoptionPreparerV1 {
+  /** Accepts capsule bytes and disclosures only; all authority and policy are host-bound. */
+  prepare(value: unknown): OhAdoptionCandidateV1;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -178,69 +143,22 @@ function validUnicode(value: string): boolean {
   return true;
 }
 
-function canonicalJson(value: unknown, path = "$", ancestors = new Set<object>()): string {
-  if (value === null || typeof value === "boolean") return JSON.stringify(value);
-  if (typeof value === "string") {
-    if (!validUnicode(value)) throw new TypeError(`${path} contains invalid Unicode.`);
-    return JSON.stringify(value);
-  }
-  if (typeof value === "number") {
-    if (!Number.isFinite(value) || Object.is(value, -0)) throw new TypeError(`${path} is not a canonical number.`);
-    return JSON.stringify(value);
-  }
-  if (typeof value !== "object" || value === null || ancestors.has(value)) {
-    throw new TypeError(`${path} is not an acyclic JSON value.`);
-  }
-  ancestors.add(value);
-  try {
-    if (Array.isArray(value)) {
-      const keys = Reflect.ownKeys(value);
-      if (keys.some((key) => key !== "length" && (typeof key !== "string"
-        || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= value.length))) {
-        throw new TypeError(`${path} has non-index array properties.`);
-      }
-      const output: string[] = [];
-      for (let index = 0; index < value.length; index += 1) {
-        if (!Object.hasOwn(value, index)) throw new TypeError(`${path} contains a sparse array.`);
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
-          throw new TypeError(`${path}[${index}] is not an enumerable data property.`);
-        }
-        output.push(canonicalJson(descriptor.value, `${path}[${index}]`, ancestors));
-      }
-      return `[${output.join(",")}]`;
-    }
-    if (!isRecord(value)) throw new TypeError(`${path} is not a plain JSON object.`);
-    const ownKeys = Reflect.ownKeys(value);
-    if (ownKeys.some((key) => typeof key !== "string")) throw new TypeError(`${path} has symbol properties.`);
-    const keys = ownKeys as string[];
-    keys.sort();
-    return `{${keys.map((key) => {
-      if (!validUnicode(key)) throw new TypeError(`${path} contains an invalid key.`);
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
-        throw new TypeError(`${path}.${key} is not an enumerable data property.`);
-      }
-      return `${JSON.stringify(key)}:${canonicalJson(descriptor.value, `${path}.${key}`, ancestors)}`;
-    }).join(",")}}`;
-  } finally {
-    ancestors.delete(value);
-  }
-}
-
-function digest(value: unknown): string {
-  return createHash("sha256").update(canonicalJson(value)).digest("hex");
-}
-
 function structurallyBounded(value: unknown): boolean {
   const pending: Array<readonly [unknown, number]> = [[value, 0]];
   const seen = new Set<object>();
   let nodes = 0;
+  let scalarBytes = 0;
   while (pending.length > 0) {
     const [candidate, depth] = pending.pop() as readonly [unknown, number];
     nodes += 1;
-    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH) return false;
-    if (typeof candidate === "string" && Buffer.byteLength(candidate, "utf8") > MAX_CAPSULE_BYTES) return false;
+    scalarBytes += 4;
+    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH
+      || scalarBytes > MAX_CAPSULE_BYTES) return false;
+    if (typeof candidate === "string") {
+      if (!validUnicode(candidate)) return false;
+      scalarBytes += Buffer.byteLength(candidate, "utf8");
+      if (scalarBytes > MAX_CAPSULE_BYTES) return false;
+    }
     if (typeof candidate !== "object" || candidate === null) continue;
     if (seen.has(candidate)) return false;
     seen.add(candidate);
@@ -259,7 +177,10 @@ function structurallyBounded(value: unknown): boolean {
       if (keys.length > MAX_STRUCTURAL_NODES || keys.some((key) => typeof key !== "string")) return false;
       for (const key of keys as string[]) {
         const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
-        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) return false;
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)
+          || !validUnicode(key)) return false;
+        scalarBytes += Buffer.byteLength(key, "utf8");
+        if (scalarBytes > MAX_CAPSULE_BYTES) return false;
         pending.push([descriptor.value, depth + 1]);
       }
     } else return false;
@@ -267,8 +188,16 @@ function structurallyBounded(value: unknown): boolean {
   return true;
 }
 
-function sha(value: unknown): string | null {
-  return typeof value === "string" && SHA256_PATTERN.test(value) ? value : null;
+function immutableClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map((item) => immutableClone(item))) as T;
+  }
+  if (isRecord(value)) {
+    const clone: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) clone[key] = immutableClone(value[key]);
+    return Object.freeze(clone) as T;
+  }
+  return value;
 }
 
 function code(value: unknown, maximum = 256): string | null {
@@ -283,138 +212,6 @@ function orderedUnique(values: readonly string[]): boolean {
   return values.every((value, index) => index === 0 || (values[index - 1] as string) < value);
 }
 
-function parseProfile(value: unknown): OhAdoptionStoreProfileV1 | null {
-  if (!isRecord(value) || !exactKeys(value, ["applicationProfileSha256", "capabilities", "profileId",
-    "profileKind", "profileSha256", "v"]) || value.v !== 1 || value.profileKind !== "working"
-    || !isRecord(value.capabilities) || !exactKeys(value.capabilities, ["changesSince",
-      "dependencyClosureExport", "exactSnapshots", "operationReplication", "semanticBundleCommit", "v",
-      "wholeSpacePurge"])) return null;
-  const capabilities = value.capabilities;
-  if (capabilities.changesSince !== true || capabilities.dependencyClosureExport !== true
-    || capabilities.exactSnapshots !== true || capabilities.operationReplication !== false
-    || capabilities.semanticBundleCommit !== true || capabilities.v !== 1
-    || capabilities.wholeSpacePurge !== true) return null;
-  const applicationProfileSha256 = value.applicationProfileSha256 === null
-    ? null : sha(value.applicationProfileSha256);
-  const profileId = code(value.profileId);
-  const profileSha256 = sha(value.profileSha256);
-  if ((value.applicationProfileSha256 !== null && applicationProfileSha256 === null)
-    || profileId === null || profileSha256 === null) return null;
-  const payload = { applicationProfileSha256, capabilities: {
-    changesSince: true as const, dependencyClosureExport: true as const, exactSnapshots: true as const,
-    operationReplication: false as const, semanticBundleCommit: true as const, v: 1 as const,
-    wholeSpacePurge: true as const,
-  }, profileId, profileKind: "working" as const, v: 1 as const };
-  return digest(payload) === profileSha256 ? { ...payload, profileSha256 } : null;
-}
-
-function parseBinding(value: unknown): OhAdoptionStoreBindingV1 | null {
-  if (!isRecord(value) || !exactKeys(value, ["bindingSha256", "contractSha256", "profile", "realmId",
-    "spaceId", "v"]) || value.v !== 1) return null;
-  const bindingSha256 = sha(value.bindingSha256);
-  const contractSha256 = sha(value.contractSha256);
-  const profile = parseProfile(value.profile);
-  const realmId = code(value.realmId);
-  const spaceId = code(value.spaceId);
-  if (bindingSha256 === null || contractSha256 === null || profile === null || realmId === null || spaceId === null) {
-    return null;
-  }
-  const payload = { contractSha256, profile, realmId, spaceId, v: 1 as const };
-  return digest(payload) === bindingSha256 ? { ...payload, bindingSha256 } : null;
-}
-
-function parseHead(value: unknown): OhAdoptionHeadV1 | null {
-  if (!isRecord(value) || !exactKeys(value, ["generation", "graphRevisionSha256", "operationSha256",
-    "recordsSha256", "sequence", "v"]) || value.v !== 1) return null;
-  const generation = Number.isSafeInteger(value.generation) && (value.generation as number) >= 0
-    ? value.generation as number : null;
-  const sequence = Number.isSafeInteger(value.sequence) && (value.sequence as number) >= 0
-    ? value.sequence as number : null;
-  const graphRevisionSha256 = value.graphRevisionSha256 === null ? null : sha(value.graphRevisionSha256);
-  const operationSha256 = value.operationSha256 === null ? null : sha(value.operationSha256);
-  const recordsSha256 = sha(value.recordsSha256);
-  return generation !== null && generation === sequence && recordsSha256 !== null
-      && (value.graphRevisionSha256 === null || graphRevisionSha256 !== null)
-      && (value.operationSha256 === null || operationSha256 !== null)
-      && ((sequence === 0) === (operationSha256 === null))
-      && ((sequence === 0) === (graphRevisionSha256 === null))
-    ? { generation, graphRevisionSha256, operationSha256, recordsSha256, sequence, v: 1 }
-    : null;
-}
-
-function parseRecord(value: unknown): OhAdoptionRecordV1 | null {
-  if (!isRecord(value) || !exactKeys(value, ["dependencies", "key", "kind", "recordSha256", "v", "value"])
-    || value.v !== 1 || !Array.isArray(value.dependencies)
-    || value.dependencies.length > MAX_DEPENDENCIES || !OH_RECORD_KINDS.has(value.kind as string)
-    || !structurallyBounded(value.value)) return null;
-  const key = recordKey(value.key);
-  const kind = typeof value.kind === "string" ? value.kind : null;
-  const recordSha256 = sha(value.recordSha256);
-  const dependencies = value.dependencies.map(recordKey);
-  if (key === null || kind === null || recordSha256 === null || dependencies.some((item) => item === null)
-    || !orderedUnique(dependencies as string[]) || dependencies.includes(key)) return null;
-  const payload = { dependencies: dependencies as string[], key, kind, v: 1 as const,
-    value: value.value as OhAdoptionJsonValue };
-  const encoded = canonicalJson(payload.value);
-  return Buffer.byteLength(encoded, "utf8") <= MAX_RECORD_BYTES && digest(payload) === recordSha256
-    ? { ...payload, recordSha256 } : null;
-}
-
-function parseExpectedSource(value: unknown): OhAdoptionExpectedSourceV1 | null {
-  if (!isRecord(value) || !exactKeys(value, ["authorityId", "binding", "head", "v"]) || value.v !== 1) return null;
-  const authorityId = code(value.authorityId);
-  const binding = parseBinding(value.binding);
-  const head = parseHead(value.head);
-  return authorityId !== null && binding !== null && head !== null
-    ? { authorityId, binding, head, v: 1 } : null;
-}
-
-/**
- * Temporary structural adapter for Oh V1 closure capsules. Replace this parser
- * with @hraness/oh's verifier when the immutable v0.2.0 release is available.
- */
-export function parseOhDependencyClosureCapsuleV1(
-  value: unknown,
-  expectedSource: unknown,
-): OhDependencyClosureCapsuleV1 | null {
-  try {
-    if (!structurallyBounded(value) || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES
-      || !isRecord(value) || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"])
-      || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots)
-      || value.records.length < 1 || value.records.length > MAX_RECORDS
-      || value.roots.length < 1 || value.roots.length > MAX_ROOTS) return null;
-    const expected = parseExpectedSource(expectedSource);
-    const binding = parseBinding(value.binding);
-    const head = parseHead(value.head);
-    const closureSha256 = sha(value.closureSha256);
-    const roots = value.roots.map(recordKey);
-    const records = value.records.map(parseRecord);
-    if (expected === null || binding === null || head === null || closureSha256 === null
-      || roots.some((root) => root === null) || !orderedUnique(roots as string[])
-      || records.some((record) => record === null)) return null;
-    const parsedRecords = records as OhAdoptionRecordV1[];
-    if (!orderedUnique(parsedRecords.map((record) => record.key))) return null;
-    if (canonicalJson(binding) !== canonicalJson(expected.binding)
-      || canonicalJson(head) !== canonicalJson(expected.head)) return null;
-    const byKey = new Map(parsedRecords.map((record) => [record.key, record]));
-    const reachable = new Set<string>();
-    const pending = [...roots as string[]];
-    while (pending.length > 0) {
-      const key = pending.pop() as string;
-      if (reachable.has(key)) continue;
-      const record = byKey.get(key);
-      if (record === undefined) return null;
-      reachable.add(key);
-      pending.push(...record.dependencies);
-    }
-    if (reachable.size !== parsedRecords.length) return null;
-    const payload = { binding, head, records: parsedRecords, roots: roots as string[], v: 1 as const };
-    return digest(payload) === closureSha256 ? { ...payload, closureSha256 } : null;
-  } catch {
-    return null;
-  }
-}
-
 function singleLine(value: unknown): string | null {
   if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value
     || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value)
@@ -422,7 +219,17 @@ function singleLine(value: unknown): string | null {
   return value;
 }
 
-function parseDestination(value: unknown): DestinationV1 | null {
+function parseExpectedSource(value: unknown): OhAdoptionExpectedSourceV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["authorityId", "binding", "head", "v"])
+    || value.v !== 1) return null;
+  const authorityId = code(value.authorityId);
+  const binding = parseOhStoreBindingV1(value.binding);
+  const head = parseOhHeadV1(value.head);
+  return authorityId !== null && binding !== null && binding.profile.profileKind === "working" && head !== null
+    ? immutableClone({ authorityId, binding, head, v: 1 }) : null;
+}
+
+function parseDestination(value: unknown): OhAdoptionDestinationV1 | null {
   if (!isRecord(value) || !exactKeys(value, ["purpose", "targetPath", "v"]) || value.v !== 1) return null;
   const purpose = code(value.purpose);
   if (purpose === null || typeof value.targetPath !== "string" || value.targetPath.length > 512
@@ -435,7 +242,7 @@ function parseDestination(value: unknown): DestinationV1 | null {
   return { purpose, targetPath: value.targetPath, v: 1 };
 }
 
-function parseRights(value: unknown, purpose: string): RightsClearanceV1 | null {
+function parseRights(value: unknown, purpose: string): OhAdoptionRightsClearanceV1 | null {
   if (!isRecord(value) || !exactKeys(value, ["decisionId", "disposition", "purpose", "v"])
     || value.v !== 1 || value.disposition !== "cleared-for-purpose" || value.purpose !== purpose) return null;
   const decisionId = code(value.decisionId);
@@ -443,14 +250,14 @@ function parseRights(value: unknown, purpose: string): RightsClearanceV1 | null 
     : { decisionId, disposition: "cleared-for-purpose", purpose, v: 1 };
 }
 
-function parseReview(value: unknown): ReviewRequirementV1 | null {
+function parseReview(value: unknown): OhAdoptionReviewRequirementV1 | null {
   if (!isRecord(value) || !exactKeys(value, ["route", "status", "v"])
     || value.v !== 1 || value.status !== "required") return null;
   const route = code(value.route);
   return route === null ? null : { route, status: "required", v: 1 };
 }
 
-function parseConflicts(value: unknown): ConflictReviewV1 | null {
+function parseConflicts(value: unknown): OhAdoptionConflictReviewV1 | null {
   if (!isRecord(value) || !exactKeys(value, ["notes", "status", "v"]) || value.v !== 1
     || (value.status !== "none-observed" && value.status !== "requires-resolution")
     || !Array.isArray(value.notes) || value.notes.length < 1 || value.notes.length > 64) return null;
@@ -460,9 +267,44 @@ function parseConflicts(value: unknown): ConflictReviewV1 | null {
   return orderedUnique(sorted) ? { notes: sorted, status: value.status, v: 1 } : null;
 }
 
-function parseDisclosures(value: unknown, keys: ReadonlySet<string>): readonly ChangeDisclosureV1[] | null {
+function parseHostPolicy(value: unknown): OhAdoptionHostPolicyV1 | null {
+  if (!structurallyBounded(value) || !isRecord(value)
+    || !exactKeys(value, ["conflicts", "destination", "expectedSource", "review", "rights", "v"])
+    || value.v !== 1) return null;
+  const destination = parseDestination(value.destination);
+  const expectedSource = parseExpectedSource(value.expectedSource);
+  const conflicts = parseConflicts(value.conflicts);
+  const review = parseReview(value.review);
+  const rights = destination === null ? null : parseRights(value.rights, destination.purpose);
+  return destination !== null && expectedSource !== null && conflicts !== null && review !== null && rights !== null
+    ? immutableClone({ conflicts, destination, expectedSource, review, rights, v: 1 }) : null;
+}
+
+function verifyCapsule(
+  value: unknown,
+  expectedSource: OhAdoptionExpectedSourceV1,
+): OhDependencyClosureV1 | null {
+  try {
+    if (!structurallyBounded(value) || !isRecord(value)
+      || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"])
+      || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots)
+      || value.records.length < 1 || value.records.length > MAX_RECORDS
+      || value.roots.length < 1 || value.roots.length > MAX_ROOTS
+      || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES) return null;
+    const verified = verifyOhDependencyClosureAgainstV1(value, {
+      binding: expectedSource.binding,
+      head: expectedSource.head,
+    });
+    return verified.ok && verified.closure.binding.profile.profileKind === "working"
+      ? verified.closure : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseDisclosures(value: unknown, keys: ReadonlySet<string>): readonly OhAdoptionChangeDisclosureV1[] | null {
   if (!Array.isArray(value) || value.length > 256) return null;
-  const parsed: ChangeDisclosureV1[] = [];
+  const parsed: OhAdoptionChangeDisclosureV1[] = [];
   for (const item of value) {
     if (!isRecord(item) || !exactKeys(item, ["id", "recordKey", "summary", "v"]) || item.v !== 1) return null;
     const id = code(item.id);
@@ -525,35 +367,27 @@ function renderMarkdown(manifest: OhAdoptionCandidateV1["manifest"], candidateSh
   return `${lines.join("\n")}\n`;
 }
 
-/**
- * Produces bytes for destination review only. This function has no filesystem,
- * Git, store-write, sync, or promotion capability.
- */
-export function prepareOhAdoptionCandidateV1(value: unknown): OhAdoptionCandidateV1 {
-  if (!isRecord(value) || !exactKeys(value, ["capsule", "conflicts", "destination", "expectedSource",
-    "redactions", "review", "rights", "transformations", "v"]) || value.v !== 1) {
-    throw new TypeError("Invalid Oh adoption candidate input.");
+function prepareWithPolicy(
+  value: unknown,
+  policy: OhAdoptionHostPolicyV1,
+): OhAdoptionCandidateV1 {
+  if (!structurallyBounded(value) || !isRecord(value)
+    || !exactKeys(value, ["capsule", "redactions", "transformations", "v"]) || value.v !== 1) {
+    throw new TypeError("Invalid Oh adoption preparation input.");
   }
-  const expectedSource = parseExpectedSource(value.expectedSource);
-  const capsule = parseOhDependencyClosureCapsuleV1(value.capsule, value.expectedSource);
-  const destination = parseDestination(value.destination);
-  if (expectedSource === null || capsule === null || destination === null) {
-    throw new TypeError("The source capsule or destination is invalid.");
-  }
-  const rights = parseRights(value.rights, destination.purpose);
-  const review = parseReview(value.review);
-  const conflicts = parseConflicts(value.conflicts);
+  const capsule = verifyCapsule(value.capsule, policy.expectedSource);
+  if (capsule === null) throw new TypeError("The source capsule is invalid for the bound authority and head.");
   const recordKeys = new Set(capsule.records.map((record) => record.key));
   const transformations = parseDisclosures(value.transformations, recordKeys);
   const redactions = parseDisclosures(value.redactions, recordKeys);
   const roots = new Set(capsule.roots);
-  if (rights === null || review === null || conflicts === null || transformations === null || redactions === null
+  if (transformations === null || redactions === null
     || capsule.records.filter((record) => roots.has(record.key)).every((record) => record.kind === "view")) {
-    throw new TypeError("Adoption requires rights, review, conflict, and authoritative-root declarations.");
+    throw new TypeError("Adoption requires valid disclosures and an authoritative root.");
   }
   const source = {
-    authorityId: expectedSource.authorityId,
-    binding: capsule.binding,
+    authorityId: policy.expectedSource.authorityId,
+    binding: { bindingSha256: capsule.binding.bindingSha256, v: 1 as const },
     closureSha256: capsule.closureSha256,
     head: capsule.head,
     records: capsule.records.map((record) => ({ dependencies: record.dependencies, key: record.key,
@@ -562,22 +396,37 @@ export function prepareOhAdoptionCandidateV1(value: unknown): OhAdoptionCandidat
     v: 1 as const,
   };
   const manifest = {
-    conflicts,
-    destination,
+    conflicts: policy.conflicts,
+    destination: policy.destination,
     format: "hraness.kb.oh-adoption-candidate.v1" as const,
     redactions,
-    review,
-    rights,
+    review: policy.review,
+    rights: policy.rights,
     source,
     status: "prepared" as const,
     transformations,
     v: 1 as const,
   };
-  const candidateSha256 = digest(manifest);
+  const candidateSha256 = canonicalSha256(manifest);
   const markdown = renderMarkdown(manifest, candidateSha256);
   if (Buffer.byteLength(markdown, "utf8") > MAX_CAPSULE_BYTES) {
     throw new RangeError("The adoption candidate exceeds its Markdown byte limit.");
   }
-  return { artifactSha256: createHash("sha256").update(markdown).digest("hex"), candidateSha256,
-    manifest, markdown, v: 1 };
+  return immutableClone({
+    artifactSha256: createHash("sha256").update(markdown).digest("hex"),
+    candidateSha256,
+    manifest,
+    markdown,
+    v: 1,
+  });
+}
+
+/**
+ * Captures all authority, destination, rights, review, and conflict policy in
+ * trusted host code. The returned facade can only prepare inert review bytes.
+ */
+export function createOhAdoptionPreparerV1(value: unknown): OhAdoptionPreparerV1 {
+  const policy = parseHostPolicy(value);
+  if (policy === null) throw new TypeError("Invalid Oh adoption host policy.");
+  return Object.freeze({ prepare: (input: unknown) => prepareWithPolicy(input, policy) });
 }

--- a/src/oh-adoption.ts
+++ b/src/oh-adoption.ts
@@ -212,9 +212,21 @@ function orderedUnique(values: readonly string[]): boolean {
   return values.every((value, index) => index === 0 || (values[index - 1] as string) < value);
 }
 
+function unsafeReviewCodePoint(codePoint: number): boolean {
+  return codePoint <= 0x1f
+    || (codePoint >= 0x7f && codePoint <= 0x9f)
+    || codePoint === 0x061c
+    || codePoint === 0x200e
+    || codePoint === 0x200f
+    || (codePoint >= 0x2028 && codePoint <= 0x202e)
+    || (codePoint >= 0x2066 && codePoint <= 0x2069)
+    || codePoint === 0xfeff;
+}
+
 function singleLine(value: unknown): string | null {
   if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value
-    || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value)
+    || !validUnicode(value) || [...value].some((character) =>
+      unsafeReviewCodePoint(character.codePointAt(0) ?? 0))
     || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES) return null;
   return value;
 }

--- a/src/oh-adoption.ts
+++ b/src/oh-adoption.ts
@@ -1,0 +1,583 @@
+import { createHash } from "node:crypto";
+import { posix } from "node:path";
+
+type JsonPrimitive = boolean | null | number | string;
+export type OhAdoptionJsonValue =
+  | JsonPrimitive
+  | readonly OhAdoptionJsonValue[]
+  | Readonly<{ [key: string]: OhAdoptionJsonValue }>;
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const CODE_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
+const RECORD_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[._:/-][a-z0-9]+)*$/u;
+const MAX_CAPSULE_BYTES = 16 * 1024 * 1024;
+const MAX_RECORDS = 1_024;
+const MAX_ROOTS = 256;
+const MAX_RECORD_BYTES = 1024 * 1024;
+const MAX_DEPENDENCIES = 4_096;
+const MAX_TEXT_BYTES = 4_096;
+const MAX_STRUCTURAL_NODES = 262_144;
+const MAX_STRUCTURAL_DEPTH = 128;
+
+const OH_RECORD_KINDS = new Set([
+  "activity", "assertion", "context", "dependency-manifest", "edition", "entity",
+  "evidence", "identity-operation", "inquiry", "inquiry-event", "review-decision",
+  "rights-decision", "schema", "shape", "statement", "type-membership", "view",
+  "vocabulary",
+]);
+
+export interface OhAdoptionStoreProfileV1 {
+  readonly applicationProfileSha256: string | null;
+  readonly capabilities: Readonly<{
+    readonly changesSince: true;
+    readonly dependencyClosureExport: true;
+    readonly exactSnapshots: true;
+    readonly operationReplication: false;
+    readonly semanticBundleCommit: true;
+    readonly v: 1;
+    readonly wholeSpacePurge: true;
+  }>;
+  readonly profileId: string;
+  readonly profileKind: "working";
+  readonly profileSha256: string;
+  readonly v: 1;
+}
+
+export interface OhAdoptionStoreBindingV1 {
+  readonly bindingSha256: string;
+  readonly contractSha256: string;
+  readonly profile: OhAdoptionStoreProfileV1;
+  readonly realmId: string;
+  readonly spaceId: string;
+  readonly v: 1;
+}
+
+export interface OhAdoptionHeadV1 {
+  readonly generation: number;
+  readonly graphRevisionSha256: string | null;
+  readonly operationSha256: string | null;
+  readonly recordsSha256: string;
+  readonly sequence: number;
+  readonly v: 1;
+}
+
+export interface OhAdoptionRecordV1 {
+  readonly dependencies: readonly string[];
+  readonly key: string;
+  readonly kind: string;
+  readonly recordSha256: string;
+  readonly v: 1;
+  readonly value: OhAdoptionJsonValue;
+}
+
+export interface OhDependencyClosureCapsuleV1 {
+  readonly binding: OhAdoptionStoreBindingV1;
+  readonly closureSha256: string;
+  readonly head: OhAdoptionHeadV1;
+  readonly records: readonly OhAdoptionRecordV1[];
+  readonly roots: readonly string[];
+  readonly v: 1;
+}
+
+export interface OhAdoptionExpectedSourceV1 {
+  readonly authorityId: string;
+  readonly binding: OhAdoptionStoreBindingV1;
+  readonly head: OhAdoptionHeadV1;
+  readonly v: 1;
+}
+
+export interface OhAdoptionCandidateV1 {
+  readonly artifactSha256: string;
+  readonly candidateSha256: string;
+  readonly manifest: Readonly<{
+    readonly conflicts: ConflictReviewV1;
+    readonly destination: DestinationV1;
+    readonly format: "hraness.kb.oh-adoption-candidate.v1";
+    readonly redactions: readonly ChangeDisclosureV1[];
+    readonly review: ReviewRequirementV1;
+    readonly rights: RightsClearanceV1;
+    readonly source: Readonly<{
+      readonly authorityId: string;
+      readonly binding: OhAdoptionStoreBindingV1;
+      readonly closureSha256: string;
+      readonly head: OhAdoptionHeadV1;
+      readonly records: readonly Readonly<{
+        readonly dependencies: readonly string[];
+        readonly key: string;
+        readonly kind: string;
+        readonly recordSha256: string;
+        readonly v: 1;
+      }>[];
+      readonly roots: readonly string[];
+      readonly v: 1;
+    }>;
+    readonly status: "prepared";
+    readonly transformations: readonly ChangeDisclosureV1[];
+    readonly v: 1;
+  }>;
+  readonly markdown: string;
+  readonly v: 1;
+}
+
+interface DestinationV1 {
+  readonly purpose: string;
+  readonly targetPath: string;
+  readonly v: 1;
+}
+
+interface RightsClearanceV1 {
+  readonly decisionId: string;
+  readonly disposition: "cleared-for-purpose";
+  readonly purpose: string;
+  readonly v: 1;
+}
+
+interface ReviewRequirementV1 {
+  readonly route: string;
+  readonly status: "required";
+  readonly v: 1;
+}
+
+interface ConflictReviewV1 {
+  readonly notes: readonly string[];
+  readonly status: "none-observed" | "requires-resolution";
+  readonly v: 1;
+}
+
+interface ChangeDisclosureV1 {
+  readonly id: string;
+  readonly recordKey: string;
+  readonly summary: string;
+  readonly v: 1;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Reflect.ownKeys(value);
+  return actual.length === keys.length && actual.every((key) => {
+    if (typeof key !== "string" || !keys.includes(key)) return false;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor !== undefined && descriptor.enumerable && "value" in descriptor;
+  });
+}
+
+function validUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) return false;
+  }
+  return true;
+}
+
+function canonicalJson(value: unknown, path = "$", ancestors = new Set<object>()): string {
+  if (value === null || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "string") {
+    if (!validUnicode(value)) throw new TypeError(`${path} contains invalid Unicode.`);
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || Object.is(value, -0)) throw new TypeError(`${path} is not a canonical number.`);
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object" || value === null || ancestors.has(value)) {
+    throw new TypeError(`${path} is not an acyclic JSON value.`);
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const keys = Reflect.ownKeys(value);
+      if (keys.some((key) => key !== "length" && (typeof key !== "string"
+        || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= value.length))) {
+        throw new TypeError(`${path} has non-index array properties.`);
+      }
+      const output: string[] = [];
+      for (let index = 0; index < value.length; index += 1) {
+        if (!Object.hasOwn(value, index)) throw new TypeError(`${path} contains a sparse array.`);
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+          throw new TypeError(`${path}[${index}] is not an enumerable data property.`);
+        }
+        output.push(canonicalJson(descriptor.value, `${path}[${index}]`, ancestors));
+      }
+      return `[${output.join(",")}]`;
+    }
+    if (!isRecord(value)) throw new TypeError(`${path} is not a plain JSON object.`);
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.some((key) => typeof key !== "string")) throw new TypeError(`${path} has symbol properties.`);
+    const keys = ownKeys as string[];
+    keys.sort();
+    return `{${keys.map((key) => {
+      if (!validUnicode(key)) throw new TypeError(`${path} contains an invalid key.`);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) {
+        throw new TypeError(`${path}.${key} is not an enumerable data property.`);
+      }
+      return `${JSON.stringify(key)}:${canonicalJson(descriptor.value, `${path}.${key}`, ancestors)}`;
+    }).join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+function structurallyBounded(value: unknown): boolean {
+  const pending: Array<readonly [unknown, number]> = [[value, 0]];
+  const seen = new Set<object>();
+  let nodes = 0;
+  while (pending.length > 0) {
+    const [candidate, depth] = pending.pop() as readonly [unknown, number];
+    nodes += 1;
+    if (nodes > MAX_STRUCTURAL_NODES || depth > MAX_STRUCTURAL_DEPTH) return false;
+    if (typeof candidate === "string" && Buffer.byteLength(candidate, "utf8") > MAX_CAPSULE_BYTES) return false;
+    if (typeof candidate !== "object" || candidate === null) continue;
+    if (seen.has(candidate)) return false;
+    seen.add(candidate);
+    if (Array.isArray(candidate)) {
+      if (candidate.length > MAX_STRUCTURAL_NODES) return false;
+      const keys = Reflect.ownKeys(candidate);
+      if (keys.some((key) => key !== "length" && (typeof key !== "string"
+        || !/^(?:0|[1-9][0-9]*)$/u.test(key) || Number(key) >= candidate.length))) return false;
+      for (let index = 0; index < candidate.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, String(index));
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) return false;
+        pending.push([descriptor.value, depth + 1]);
+      }
+    } else if (isRecord(candidate)) {
+      const keys = Reflect.ownKeys(candidate);
+      if (keys.length > MAX_STRUCTURAL_NODES || keys.some((key) => typeof key !== "string")) return false;
+      for (const key of keys as string[]) {
+        const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+        if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) return false;
+        pending.push([descriptor.value, depth + 1]);
+      }
+    } else return false;
+  }
+  return true;
+}
+
+function sha(value: unknown): string | null {
+  return typeof value === "string" && SHA256_PATTERN.test(value) ? value : null;
+}
+
+function code(value: unknown, maximum = 256): string | null {
+  return typeof value === "string" && value.length <= maximum && CODE_PATTERN.test(value) ? value : null;
+}
+
+function recordKey(value: unknown): string | null {
+  return typeof value === "string" && value.length <= 512 && RECORD_KEY_PATTERN.test(value) ? value : null;
+}
+
+function orderedUnique(values: readonly string[]): boolean {
+  return values.every((value, index) => index === 0 || (values[index - 1] as string) < value);
+}
+
+function parseProfile(value: unknown): OhAdoptionStoreProfileV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["applicationProfileSha256", "capabilities", "profileId",
+    "profileKind", "profileSha256", "v"]) || value.v !== 1 || value.profileKind !== "working"
+    || !isRecord(value.capabilities) || !exactKeys(value.capabilities, ["changesSince",
+      "dependencyClosureExport", "exactSnapshots", "operationReplication", "semanticBundleCommit", "v",
+      "wholeSpacePurge"])) return null;
+  const capabilities = value.capabilities;
+  if (capabilities.changesSince !== true || capabilities.dependencyClosureExport !== true
+    || capabilities.exactSnapshots !== true || capabilities.operationReplication !== false
+    || capabilities.semanticBundleCommit !== true || capabilities.v !== 1
+    || capabilities.wholeSpacePurge !== true) return null;
+  const applicationProfileSha256 = value.applicationProfileSha256 === null
+    ? null : sha(value.applicationProfileSha256);
+  const profileId = code(value.profileId);
+  const profileSha256 = sha(value.profileSha256);
+  if ((value.applicationProfileSha256 !== null && applicationProfileSha256 === null)
+    || profileId === null || profileSha256 === null) return null;
+  const payload = { applicationProfileSha256, capabilities: {
+    changesSince: true as const, dependencyClosureExport: true as const, exactSnapshots: true as const,
+    operationReplication: false as const, semanticBundleCommit: true as const, v: 1 as const,
+    wholeSpacePurge: true as const,
+  }, profileId, profileKind: "working" as const, v: 1 as const };
+  return digest(payload) === profileSha256 ? { ...payload, profileSha256 } : null;
+}
+
+function parseBinding(value: unknown): OhAdoptionStoreBindingV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["bindingSha256", "contractSha256", "profile", "realmId",
+    "spaceId", "v"]) || value.v !== 1) return null;
+  const bindingSha256 = sha(value.bindingSha256);
+  const contractSha256 = sha(value.contractSha256);
+  const profile = parseProfile(value.profile);
+  const realmId = code(value.realmId);
+  const spaceId = code(value.spaceId);
+  if (bindingSha256 === null || contractSha256 === null || profile === null || realmId === null || spaceId === null) {
+    return null;
+  }
+  const payload = { contractSha256, profile, realmId, spaceId, v: 1 as const };
+  return digest(payload) === bindingSha256 ? { ...payload, bindingSha256 } : null;
+}
+
+function parseHead(value: unknown): OhAdoptionHeadV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["generation", "graphRevisionSha256", "operationSha256",
+    "recordsSha256", "sequence", "v"]) || value.v !== 1) return null;
+  const generation = Number.isSafeInteger(value.generation) && (value.generation as number) >= 0
+    ? value.generation as number : null;
+  const sequence = Number.isSafeInteger(value.sequence) && (value.sequence as number) >= 0
+    ? value.sequence as number : null;
+  const graphRevisionSha256 = value.graphRevisionSha256 === null ? null : sha(value.graphRevisionSha256);
+  const operationSha256 = value.operationSha256 === null ? null : sha(value.operationSha256);
+  const recordsSha256 = sha(value.recordsSha256);
+  return generation !== null && generation === sequence && recordsSha256 !== null
+      && (value.graphRevisionSha256 === null || graphRevisionSha256 !== null)
+      && (value.operationSha256 === null || operationSha256 !== null)
+      && ((sequence === 0) === (operationSha256 === null))
+      && ((sequence === 0) === (graphRevisionSha256 === null))
+    ? { generation, graphRevisionSha256, operationSha256, recordsSha256, sequence, v: 1 }
+    : null;
+}
+
+function parseRecord(value: unknown): OhAdoptionRecordV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["dependencies", "key", "kind", "recordSha256", "v", "value"])
+    || value.v !== 1 || !Array.isArray(value.dependencies)
+    || value.dependencies.length > MAX_DEPENDENCIES || !OH_RECORD_KINDS.has(value.kind as string)
+    || !structurallyBounded(value.value)) return null;
+  const key = recordKey(value.key);
+  const kind = typeof value.kind === "string" ? value.kind : null;
+  const recordSha256 = sha(value.recordSha256);
+  const dependencies = value.dependencies.map(recordKey);
+  if (key === null || kind === null || recordSha256 === null || dependencies.some((item) => item === null)
+    || !orderedUnique(dependencies as string[]) || dependencies.includes(key)) return null;
+  const payload = { dependencies: dependencies as string[], key, kind, v: 1 as const,
+    value: value.value as OhAdoptionJsonValue };
+  const encoded = canonicalJson(payload.value);
+  return Buffer.byteLength(encoded, "utf8") <= MAX_RECORD_BYTES && digest(payload) === recordSha256
+    ? { ...payload, recordSha256 } : null;
+}
+
+function parseExpectedSource(value: unknown): OhAdoptionExpectedSourceV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["authorityId", "binding", "head", "v"]) || value.v !== 1) return null;
+  const authorityId = code(value.authorityId);
+  const binding = parseBinding(value.binding);
+  const head = parseHead(value.head);
+  return authorityId !== null && binding !== null && head !== null
+    ? { authorityId, binding, head, v: 1 } : null;
+}
+
+/**
+ * Temporary structural adapter for Oh V1 closure capsules. Replace this parser
+ * with @hraness/oh's verifier when the immutable v0.2.0 release is available.
+ */
+export function parseOhDependencyClosureCapsuleV1(
+  value: unknown,
+  expectedSource: unknown,
+): OhDependencyClosureCapsuleV1 | null {
+  try {
+    if (!structurallyBounded(value) || Buffer.byteLength(canonicalJson(value), "utf8") > MAX_CAPSULE_BYTES
+      || !isRecord(value) || !exactKeys(value, ["binding", "closureSha256", "head", "records", "roots", "v"])
+      || value.v !== 1 || !Array.isArray(value.records) || !Array.isArray(value.roots)
+      || value.records.length < 1 || value.records.length > MAX_RECORDS
+      || value.roots.length < 1 || value.roots.length > MAX_ROOTS) return null;
+    const expected = parseExpectedSource(expectedSource);
+    const binding = parseBinding(value.binding);
+    const head = parseHead(value.head);
+    const closureSha256 = sha(value.closureSha256);
+    const roots = value.roots.map(recordKey);
+    const records = value.records.map(parseRecord);
+    if (expected === null || binding === null || head === null || closureSha256 === null
+      || roots.some((root) => root === null) || !orderedUnique(roots as string[])
+      || records.some((record) => record === null)) return null;
+    const parsedRecords = records as OhAdoptionRecordV1[];
+    if (!orderedUnique(parsedRecords.map((record) => record.key))) return null;
+    if (canonicalJson(binding) !== canonicalJson(expected.binding)
+      || canonicalJson(head) !== canonicalJson(expected.head)) return null;
+    const byKey = new Map(parsedRecords.map((record) => [record.key, record]));
+    const reachable = new Set<string>();
+    const pending = [...roots as string[]];
+    while (pending.length > 0) {
+      const key = pending.pop() as string;
+      if (reachable.has(key)) continue;
+      const record = byKey.get(key);
+      if (record === undefined) return null;
+      reachable.add(key);
+      pending.push(...record.dependencies);
+    }
+    if (reachable.size !== parsedRecords.length) return null;
+    const payload = { binding, head, records: parsedRecords, roots: roots as string[], v: 1 as const };
+    return digest(payload) === closureSha256 ? { ...payload, closureSha256 } : null;
+  } catch {
+    return null;
+  }
+}
+
+function singleLine(value: unknown): string | null {
+  if (typeof value !== "string" || value.length < 1 || value.normalize("NFC") !== value
+    || !validUnicode(value) || /[\u0000-\u001f\u007f-\u009f]/u.test(value)
+    || Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES) return null;
+  return value;
+}
+
+function parseDestination(value: unknown): DestinationV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["purpose", "targetPath", "v"]) || value.v !== 1) return null;
+  const purpose = code(value.purpose);
+  if (purpose === null || typeof value.targetPath !== "string" || value.targetPath.length > 512
+    || value.targetPath.includes("\\") || value.targetPath.startsWith("/")
+    || posix.normalize(value.targetPath) !== value.targetPath
+    || !/^notes\/[a-z0-9][a-z0-9._/-]*\.md$/u.test(value.targetPath)
+    || value.targetPath.split("/").some((segment) => segment === "." || segment === ".." || segment.startsWith("."))) {
+    return null;
+  }
+  return { purpose, targetPath: value.targetPath, v: 1 };
+}
+
+function parseRights(value: unknown, purpose: string): RightsClearanceV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["decisionId", "disposition", "purpose", "v"])
+    || value.v !== 1 || value.disposition !== "cleared-for-purpose" || value.purpose !== purpose) return null;
+  const decisionId = code(value.decisionId);
+  return decisionId === null ? null
+    : { decisionId, disposition: "cleared-for-purpose", purpose, v: 1 };
+}
+
+function parseReview(value: unknown): ReviewRequirementV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["route", "status", "v"])
+    || value.v !== 1 || value.status !== "required") return null;
+  const route = code(value.route);
+  return route === null ? null : { route, status: "required", v: 1 };
+}
+
+function parseConflicts(value: unknown): ConflictReviewV1 | null {
+  if (!isRecord(value) || !exactKeys(value, ["notes", "status", "v"]) || value.v !== 1
+    || (value.status !== "none-observed" && value.status !== "requires-resolution")
+    || !Array.isArray(value.notes) || value.notes.length < 1 || value.notes.length > 64) return null;
+  const notes = value.notes.map(singleLine);
+  if (notes.some((note) => note === null)) return null;
+  const sorted = [...notes as string[]].sort();
+  return orderedUnique(sorted) ? { notes: sorted, status: value.status, v: 1 } : null;
+}
+
+function parseDisclosures(value: unknown, keys: ReadonlySet<string>): readonly ChangeDisclosureV1[] | null {
+  if (!Array.isArray(value) || value.length > 256) return null;
+  const parsed: ChangeDisclosureV1[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || !exactKeys(item, ["id", "recordKey", "summary", "v"]) || item.v !== 1) return null;
+    const id = code(item.id);
+    const key = recordKey(item.recordKey);
+    const summary = singleLine(item.summary);
+    if (id === null || key === null || summary === null || !keys.has(key)) return null;
+    parsed.push({ id, recordKey: key, summary, v: 1 });
+  }
+  parsed.sort((left, right) => left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+  return orderedUnique(parsed.map((item) => item.id)) ? parsed : null;
+}
+
+function markdownEscape(value: string): string {
+  return value.replace(/[\\`*_{}\[\]<>()#+.!|>-]/gu, "\\$&");
+}
+
+function renderMarkdown(manifest: OhAdoptionCandidateV1["manifest"], candidateSha256: string): string {
+  const lines = [
+    "# Oh adoption candidate",
+    "",
+    `- Status: \`${manifest.status}\``,
+    `- Candidate: \`sha256:${candidateSha256}\``,
+    `- Destination: \`${manifest.destination.targetPath}\``,
+    `- Purpose: \`${manifest.destination.purpose}\``,
+    `- Source authority: \`${manifest.source.authorityId}\``,
+    `- Source binding: \`${manifest.source.binding.bindingSha256}\``,
+    `- Source head sequence: \`${manifest.source.head.sequence}\``,
+    `- Source head operation: \`${manifest.source.head.operationSha256 ?? "empty"}\``,
+    `- Source graph revision: \`${manifest.source.head.graphRevisionSha256 ?? "empty"}\``,
+    `- Source records digest: \`${manifest.source.head.recordsSha256}\``,
+    `- Closure: \`${manifest.source.closureSha256}\``,
+    "",
+    "This is a review candidate, not reviewed knowledge. It does not mutate a vault or adopt the source operation chain, database, projection, or derived tuples.",
+    "",
+    "## Required decisions",
+    "",
+    `- Rights: \`${manifest.rights.disposition}\` via \`${manifest.rights.decisionId}\` for \`${manifest.rights.purpose}\``,
+    `- Review: \`${manifest.review.status}\` via \`${manifest.review.route}\``,
+    `- Conflicts: \`${manifest.conflicts.status}\``,
+    ...manifest.conflicts.notes.map((note) => `  - ${markdownEscape(note)}`),
+    "",
+    "## Selected roots",
+    "",
+    ...manifest.source.roots.map((root) => `- \`${root}\``),
+    "",
+    "## Exact source records",
+    "",
+  ];
+  for (const record of manifest.source.records) {
+    lines.push(`### \`${record.key}\``, "", `- Kind: \`${record.kind}\``,
+      `- Digest: \`${record.recordSha256}\``,
+      `- Dependencies: ${record.dependencies.length === 0 ? "none" : record.dependencies.map((key) => `\`${key}\``).join(", ")}`, "");
+  }
+  lines.push("## Transformations", "",
+    ...(manifest.transformations.length === 0 ? ["- None declared."] : manifest.transformations.map((item) =>
+      `- \`${item.id}\` on \`${item.recordKey}\`: ${markdownEscape(item.summary)}`)), "",
+    "## Redactions", "",
+    ...(manifest.redactions.length === 0 ? ["- None declared."] : manifest.redactions.map((item) =>
+      `- \`${item.id}\` on \`${item.recordKey}\`: ${markdownEscape(item.summary)}`)), "");
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Produces bytes for destination review only. This function has no filesystem,
+ * Git, store-write, sync, or promotion capability.
+ */
+export function prepareOhAdoptionCandidateV1(value: unknown): OhAdoptionCandidateV1 {
+  if (!isRecord(value) || !exactKeys(value, ["capsule", "conflicts", "destination", "expectedSource",
+    "redactions", "review", "rights", "transformations", "v"]) || value.v !== 1) {
+    throw new TypeError("Invalid Oh adoption candidate input.");
+  }
+  const expectedSource = parseExpectedSource(value.expectedSource);
+  const capsule = parseOhDependencyClosureCapsuleV1(value.capsule, value.expectedSource);
+  const destination = parseDestination(value.destination);
+  if (expectedSource === null || capsule === null || destination === null) {
+    throw new TypeError("The source capsule or destination is invalid.");
+  }
+  const rights = parseRights(value.rights, destination.purpose);
+  const review = parseReview(value.review);
+  const conflicts = parseConflicts(value.conflicts);
+  const recordKeys = new Set(capsule.records.map((record) => record.key));
+  const transformations = parseDisclosures(value.transformations, recordKeys);
+  const redactions = parseDisclosures(value.redactions, recordKeys);
+  const roots = new Set(capsule.roots);
+  if (rights === null || review === null || conflicts === null || transformations === null || redactions === null
+    || capsule.records.filter((record) => roots.has(record.key)).every((record) => record.kind === "view")) {
+    throw new TypeError("Adoption requires rights, review, conflict, and authoritative-root declarations.");
+  }
+  const source = {
+    authorityId: expectedSource.authorityId,
+    binding: capsule.binding,
+    closureSha256: capsule.closureSha256,
+    head: capsule.head,
+    records: capsule.records.map((record) => ({ dependencies: record.dependencies, key: record.key,
+      kind: record.kind, recordSha256: record.recordSha256, v: 1 as const })),
+    roots: capsule.roots,
+    v: 1 as const,
+  };
+  const manifest = {
+    conflicts,
+    destination,
+    format: "hraness.kb.oh-adoption-candidate.v1" as const,
+    redactions,
+    review,
+    rights,
+    source,
+    status: "prepared" as const,
+    transformations,
+    v: 1 as const,
+  };
+  const candidateSha256 = digest(manifest);
+  const markdown = renderMarkdown(manifest, candidateSha256);
+  if (Buffer.byteLength(markdown, "utf8") > MAX_CAPSULE_BYTES) {
+    throw new RangeError("The adoption candidate exceeds its Markdown byte limit.");
+  }
+  return { artifactSha256: createHash("sha256").update(markdown).digest("hex"), candidateSha256,
+    manifest, markdown, v: 1 };
+}


### PR DESCRIPTION
## Summary

- add an immutable, host-policy-bound adapter for preparing reviewed Oh dependency-closure adoption candidates
- keep Markdown and Git as KB authority; the adapter has no write, purge, filesystem, or repository capability
- pin the released Oh v0.2.0 API and harden all reviewer-visible disclosures against terminal and bidirectional control spoofing
- stage package metadata for v0.18.0

## Verification

- `bun run check` (1,204 tests, 12,323 assertions)
- focused adversarial adoption suite (8 tests, 216 assertions)
- canonical package identity and historical recovery smokes

## Release

Merge stages v0.18.0 through the repository OIDC workflow. Final npm approval remains the documented two-factor human terminal step.