### PR TITLE
release: prepare KB v0.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global @hraness/kb@0.18.0
+bun add --global @hraness/kb@0.18.1
 kb --help
 ```
 
@@ -219,9 +219,9 @@ Treat the knowledge base as repository-adjacent durable memory. Authored Markdow
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.18.0` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.18.1` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
-`@hraness/kb@0.18.0` registry release only when the command is missing. Verify it
+`@hraness/kb@0.18.1` registry release only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
 I ask.
 ```
@@ -229,25 +229,25 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.18.0
-bunx skills add hraness/kb#v0.18.0
+npx skills add hraness/kb#v0.18.1
+bunx skills add hraness/kb#v0.18.1
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.18.0` npm version.
+CLI from the immutable `@hraness/kb@0.18.1` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.18.0` npm package includes the same tree under
+`0.18.1` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.18.0
+bun add --global @hraness/kb@0.18.1
 kb --help
 kb-evaluation-builder --help
 ```
@@ -255,7 +255,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.18.0
+npm install --global --ignore-scripts @hraness/kb@0.18.1
 kb --help
 ```
 
@@ -268,7 +268,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.18.0
+bun add --exact @hraness/kb@0.18.1
 ```
 
 The resulting dependency should remain exact:
@@ -276,12 +276,12 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.18.0"
+    "@hraness/kb": "0.18.1"
   }
 }
 ```
 
-Version 0.18.0 retains three public GitHub dependencies: `@hraness/oh` at
+Version 0.18.1 retains three public GitHub dependencies: `@hraness/oh` at
 immutable release `v0.2.0` for closure verification,
 `@steipete/sweet-cookie` at Hraness release `v0.4.2` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
@@ -545,9 +545,9 @@ a vault. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.18.0
+npx skills add hraness/kb#v0.18.1
 # or
-bunx skills add hraness/kb#v0.18.0
+bunx skills add hraness/kb#v0.18.1
 ```
 
 The skill invokes the installed `kb` command without depending on a repository
@@ -559,6 +559,13 @@ repository agents but is marked internal, so public skill discovery omits it.
 See [Design](docs/design.md), [Portfolio federation](docs/portfolio.md), [Agent workflow](docs/agent-workflow.md), [PDF capture](docs/pdf.md), and [Contributing](CONTRIBUTING.md) for the durable contracts and development gate. hraness/kb is available under the [MIT License](LICENSE).
 
 ## Release notes
+
+### Upgrade to v0.18.1
+
+Version 0.18.1 restructures the public README and hosted projection around one
+durable note, the exact recovery workflow, inspectable retrieval signals, and
+explicit authority boundaries. Runtime APIs and package behavior are
+unchanged.
 
 ### Upgrade to v0.18.0
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -131,7 +131,7 @@ keep the tag and npm version immutable. After the recovery workflow is on
 current `main`, dispatch it with the existing tag:
 
 ```sh
-gh workflow run release.yml --ref main -f tag=v0.18.0
+gh workflow run release.yml --ref main -f tag=v0.18.1
 ```
 
 The recovery path accepts only the newest stable repository tag. It freshly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.18.0"
+      "version": "0.18.1"
     }
   ],
   "dependencies": [

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -120,7 +120,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.18.0",
+      version: "0.18.1",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",
@@ -410,7 +410,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(201);
-      expect(verified.unpackedBytes).toBe(4_897_069);
+      expect(verified.unpackedBytes).toBe(4_897_331);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -32,7 +32,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.18.0
+  bun add --global @hraness/kb@0.18.1
 }
 kb --help
 ```


### PR DESCRIPTION
## Summary

- release the redesigned public README and hosted projection as KB v0.18.1
- align install guidance, public skill metadata, inventory, and recovery documentation
- retain all runtime APIs and behavior unchanged

## Verification

- complete `bun run check` through `hra-host-run`
- 1,208 tests / 12,345 assertions
- package boundary and historical v0.17.1 recovery smoke
- workflow, inventory, TypeScript, build, and Rust metadata-helper gates