### PR TITLE
feat: adopt Sweet Cookie v0.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global @hraness/kb@0.19.0
+bun add --global @hraness/kb@0.19.1
 kb --help
 ```
 
@@ -260,9 +260,9 @@ Treat the knowledge base as repository-adjacent durable memory. Authored Markdow
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.19.0` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.19.1` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
-`@hraness/kb@0.19.0` registry release only when the command is missing. Verify it
+`@hraness/kb@0.19.1` registry release only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
 I ask.
 ```
@@ -270,25 +270,25 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.19.0
-bunx skills add hraness/kb#v0.19.0
+npx skills add hraness/kb#v0.19.1
+bunx skills add hraness/kb#v0.19.1
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.19.0` npm version.
+CLI from the immutable `@hraness/kb@0.19.1` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.19.0` npm package includes the same tree under
+`0.19.1` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.19.0
+bun add --global @hraness/kb@0.19.1
 kb --help
 kb-evaluation-builder --help
 ```
@@ -296,7 +296,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.19.0
+npm install --global --ignore-scripts @hraness/kb@0.19.1
 kb --help
 ```
 
@@ -309,7 +309,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.19.0
+bun add --exact @hraness/kb@0.19.1
 ```
 
 The resulting dependency should remain exact:
@@ -317,14 +317,14 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.19.0"
+    "@hraness/kb": "0.19.1"
   }
 }
 ```
 
-Version 0.19.0 retains three public GitHub dependencies: `@hraness/oh` at
+Version 0.19.1 retains three public GitHub dependencies: `@hraness/oh` at
 immutable release `v0.2.0` for closure verification,
-`@steipete/sweet-cookie` at Hraness release `v0.4.2` for the cookie-scope safety
+`@steipete/sweet-cookie` at Hraness release `v0.4.4` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
 `aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior. A
 registry installation therefore needs Git and public GitHub access while it
@@ -593,9 +593,9 @@ ritual. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.19.0
+npx skills add hraness/kb#v0.19.1
 # or
-bunx skills add hraness/kb#v0.19.0
+bunx skills add hraness/kb#v0.19.1
 ```
 
 The skill invokes the installed `kb` command without depending on a repository
@@ -609,6 +609,15 @@ discovery omits it.
 See [Design](docs/design.md), [Portfolio federation](docs/portfolio.md), [Agent workflow](docs/agent-workflow.md), [PDF capture](docs/pdf.md), and [Contributing](CONTRIBUTING.md) for the durable contracts and development gate. hraness/kb is available under the [MIT License](LICENSE).
 
 ## Release notes
+
+### Upgrade to v0.19.1
+
+Version 0.19.1 updates the pinned Hraness Sweet Cookie fork to v0.4.4. Cookie
+ingestion now rejects records marked `partitionKeyOpaque: true` even when
+`partitionKey` is missing or null. If every selected inline cookie has
+unsupported isolation provenance, Sweet Cookie returns no cookies instead of
+falling back to browser stores. Explicit `partitionKeyOpaque: false` remains
+replayable, while malformed marker values fail closed.
 
 ### Upgrade to v0.19.0
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@hraness/kb",
       "dependencies": {
         "@hraness/oh": "github:hraness/oh#v0.2.0",
-        "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
+        "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
         "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
         "agent-browser": "0.32.3",
         "defuddle": "0.19.1",
@@ -91,7 +91,7 @@
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
-    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@github:hraness/sweet-cookie#04ddf06", { "bin": { "sweet-cookie": "packages/core/dist/cli.js" } }, "hraness-sweet-cookie-04ddf06", "sha512-SxVC8mp7OiWY4RHtBPlDl51xpRDTh8lNctnLdUGdos62oflrrroC3qQZ/YMdR2Vd62wKUBmnErBlrLumTuj2cw=="],
+    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@github:hraness/sweet-cookie#1a8b6f0", { "bin": { "sweet-cookie": "packages/core/dist/cli.js" } }, "hraness-sweet-cookie-1a8b6f0", "sha512-gL+Gu9WsBbE0Xk1xaXOYESKChl0y8HEGYl7Oi8c4MhR0Q+Tu8YjqVQi8hk/sOg5wL6gddUcpz7sGn8augLNUFw=="],
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 

--- a/dist/capture.js
+++ b/dist/capture.js
@@ -5,15 +5,15 @@ import {
   captureSummary,
   main,
   runCapture
-} from "./index-0kavxzqj.js";
+} from "./index-4p20c2mx.js";
 import"./index-7fzc32gf.js";
 import"./index-f984hw45.js";
 import {
   adapterCapabilities,
   inspectClipEnvironment,
   renderDoctorReport
-} from "./index-1n418kb9.js";
-import"./index-qry4vhxk.js";
+} from "./index-210486vj.js";
+import"./index-5vdj4pae.js";
 import"./index-hgve9rh2.js";
 import"./index-w2zc0vwa.js";
 import"./index-e5fbsywq.js";
@@ -22,7 +22,7 @@ import {
 } from "./index-6g2pv9d2.js";
 import"./index-gh719d91.js";
 import"./index-mxxxytys.js";
-import"./index-84x0vjjp.js";
+import"./index-bnmax0dq.js";
 import"./index-1xxnjn0d.js";
 import"./index-5n05se68.js";
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -114,13 +114,13 @@ import {
 } from "./index-ekpwvbra.js";
 import {
   main
-} from "./index-0kavxzqj.js";
+} from "./index-4p20c2mx.js";
 import"./index-7fzc32gf.js";
 import"./index-f984hw45.js";
-import"./index-1n418kb9.js";
+import"./index-210486vj.js";
 import {
   findKbPackageRoot
-} from "./index-qry4vhxk.js";
+} from "./index-5vdj4pae.js";
 import"./index-hgve9rh2.js";
 import"./index-w2zc0vwa.js";
 import"./index-e5fbsywq.js";
@@ -129,7 +129,7 @@ import"./index-gh719d91.js";
 import {
   redactSensitiveText
 } from "./index-mxxxytys.js";
-import"./index-84x0vjjp.js";
+import"./index-bnmax0dq.js";
 import {
   sanitizeTerminalLine,
   sanitizeTerminalText

--- a/dist/clip/acquire.js
+++ b/dist/clip/acquire.js
@@ -22,14 +22,14 @@ import {
   mergeRenderedTextSnapshots,
   readBrowserExpansionTelemetry,
   seedOwnedBrowserCookies
-} from "../index-qry4vhxk.js";
+} from "../index-5vdj4pae.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";
 import"../index-e5fbsywq.js";
 import"../index-6g2pv9d2.js";
 import"../index-gh719d91.js";
 import"../index-mxxxytys.js";
-import"../index-84x0vjjp.js";
+import"../index-bnmax0dq.js";
 import"../index-1xxnjn0d.js";
 export {
   seedOwnedBrowserCookies,

--- a/dist/clip/cli.js
+++ b/dist/clip/cli.js
@@ -5,18 +5,18 @@ import {
   captureSucceeded,
   captureSummary,
   main
-} from "../index-0kavxzqj.js";
+} from "../index-4p20c2mx.js";
 import"../index-7fzc32gf.js";
 import"../index-f984hw45.js";
-import"../index-1n418kb9.js";
-import"../index-qry4vhxk.js";
+import"../index-210486vj.js";
+import"../index-5vdj4pae.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";
 import"../index-e5fbsywq.js";
 import"../index-6g2pv9d2.js";
 import"../index-gh719d91.js";
 import"../index-mxxxytys.js";
-import"../index-84x0vjjp.js";
+import"../index-bnmax0dq.js";
 import"../index-1xxnjn0d.js";
 import"../index-5n05se68.js";
 export {

--- a/dist/clip/cookies.js
+++ b/dist/clip/cookies.js
@@ -8,7 +8,7 @@ import {
   readCookieFile,
   renderCookieHeader,
   renderNetscapeCookieJar
-} from "../index-84x0vjjp.js";
+} from "../index-bnmax0dq.js";
 export {
   renderNetscapeCookieJar,
   renderCookieHeader,

--- a/dist/clip/doctor.js
+++ b/dist/clip/doctor.js
@@ -9,15 +9,15 @@ import {
   renderAdapterCapabilities,
   renderDoctorReport,
   runDiagnosticCommand
-} from "../index-1n418kb9.js";
-import"../index-qry4vhxk.js";
+} from "../index-210486vj.js";
+import"../index-5vdj4pae.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";
 import"../index-e5fbsywq.js";
 import"../index-6g2pv9d2.js";
 import"../index-gh719d91.js";
 import"../index-mxxxytys.js";
-import"../index-84x0vjjp.js";
+import"../index-bnmax0dq.js";
 import"../index-1xxnjn0d.js";
 export {
   runDiagnosticCommand,

--- a/dist/index-210486vj.js
+++ b/dist/index-210486vj.js
@@ -2,7 +2,7 @@
 import {
   findKbPackageRoot,
   isolatedAgentBrowserEnvironment
-} from "./index-qry4vhxk.js";
+} from "./index-5vdj4pae.js";
 import {
   BoundedByteBuffer
 } from "./index-gh719d91.js";
@@ -23,7 +23,7 @@ var homebrewSqliteLibraryPaths = [
 var dependencyVersions = {
   defuddle: "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.2",
+  "@steipete/sweet-cookie": "0.4.4",
   "@tobilu/qmd": expectedQmdVersion
 };
 var dependencyNames = [

--- a/dist/index-4p20c2mx.js
+++ b/dist/index-4p20c2mx.js
@@ -18,7 +18,7 @@ import {
   inspectClipEnvironment,
   renderAdapterCapabilities,
   renderDoctorReport
-} from "./index-1n418kb9.js";
+} from "./index-210486vj.js";
 import {
   acquireBrowser,
   acquireCookieHttp,
@@ -26,7 +26,7 @@ import {
   acquireFile,
   acquireHttp,
   assertSafePersistentProfile
-} from "./index-qry4vhxk.js";
+} from "./index-5vdj4pae.js";
 import {
   CONTENT_REWRITE_TRUNCATION_WARNING,
   buildClipMarkdown,
@@ -70,7 +70,7 @@ import {
   readCookieFile,
   renderCookieHeader,
   renderNetscapeCookieJar
-} from "./index-84x0vjjp.js";
+} from "./index-bnmax0dq.js";
 import {
   sanitizeTerminalLine,
   sanitizeTerminalText

--- a/dist/index-5vdj4pae.js
+++ b/dist/index-5vdj4pae.js
@@ -23,7 +23,7 @@ import {
   filterCookieProviderResult,
   readCookieFile,
   renderCookieHeader
-} from "./index-84x0vjjp.js";
+} from "./index-bnmax0dq.js";
 
 // src/clip/acquire.ts
 import {

--- a/dist/index-bnmax0dq.js
+++ b/dist/index-bnmax0dq.js
@@ -122,7 +122,7 @@ function hasSafeUnpartitionedProvenance(value) {
     if (typeof provenance !== "string" || provenance.trim() !== "")
       return false;
   }
-  for (const field of ["partitioned"]) {
+  for (const field of ["partitioned", "partitionKeyOpaque"]) {
     const flag = value[field];
     if (flag === undefined || flag === null)
       continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {
@@ -393,7 +393,7 @@
   },
   "dependencies": {
     "@hraness/oh": "github:hraness/oh#v0.2.0",
-    "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
+    "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
     "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
     "agent-browser": "0.32.3",
     "defuddle": "0.19.1",

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.19.0"
+      "version": "0.19.1"
     }
   ],
   "dependencies": [
@@ -22,7 +22,7 @@
     {
       "from": "@hraness/kb",
       "scope": "runtime",
-      "specifier": "github:hraness/sweet-cookie#v0.4.2",
+      "specifier": "github:hraness/sweet-cookie#v0.4.4",
       "to": "@steipete/sweet-cookie",
       "sourceRepository": "hraness/sweet-cookie"
     },

--- a/scripts/kb-skill-contract.test.ts
+++ b/scripts/kb-skill-contract.test.ts
@@ -191,7 +191,7 @@ test("the shipped skill resources preserve routing and companion contracts", asy
     "references/url-platforms.md",
     "templates/companion-skill.template.md",
   ]);
-  expect(manifest.version).toBe("0.19.0");
+  expect(manifest.version).toBe("0.19.1");
   expect(manifestFiles).toContain("skills/kb");
   expect(publicSourceFiles).toContain("src/repository-memory.ts");
   expect(Object.keys(manifest.exports as Record<string, unknown>).toSorted()).toEqual([

--- a/scripts/kb-skill-contract.ts
+++ b/scripts/kb-skill-contract.ts
@@ -418,8 +418,8 @@ export function validateKbSkillContractResources(
       errors.push(`SKILL.md must link ${link}`);
     }
   }
-  if (!resources.skill.includes("bun add --global @hraness/kb@0.19.0")) {
-    errors.push("SKILL.md must retain the immutable 0.19.0 runtime pin");
+  if (!resources.skill.includes("bun add --global @hraness/kb@0.19.1")) {
+    errors.push("SKILL.md must retain the immutable 0.19.1 runtime pin");
   }
   for (const [name, contents, headings] of [
     ["customize.md", resources.customize, CUSTOMIZE_HEADINGS],

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -385,7 +385,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.19.0",
+      version: "0.19.1",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",
@@ -1980,7 +1980,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(204);
-      expect(verified.unpackedBytes).toBe(4_980_722);
+      expect(verified.unpackedBytes).toBe(4_981_223);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -55,7 +55,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.19.0
+  bun add --global @hraness/kb@0.19.1
 }
 kb --help
 ```

--- a/src/clip/cookies.test.ts
+++ b/src/clip/cookies.test.ts
@@ -150,6 +150,66 @@ describe("strict browser-like cookie filtering", () => {
     }
   });
 
+  test("installed provider does not fall back after every selected inline cookie has opaque isolation", async () => {
+    const profile = mkdtempSync(join(tmpdir(), "hraness-kb-sweet-cookie-inline-isolation-test-"));
+    const database = new Database(join(profile, "cookies.sqlite"));
+    try {
+      database.exec(`
+        CREATE TABLE moz_cookies (
+          name TEXT,
+          value TEXT,
+          host TEXT,
+          path TEXT,
+          expiry INTEGER,
+          isSecure INTEGER,
+          isHttpOnly INTEGER,
+          sameSite INTEGER,
+          originAttributes TEXT,
+          isPartitionedAttributeSet INTEGER
+        );
+        INSERT INTO moz_cookies
+          (name, value, host, path, expiry, isSecure, isHttpOnly, sameSite, originAttributes, isPartitionedAttributeSet)
+        VALUES ('fallback', 'must-not-be-read', 'example.com', '/', ${future}, 1, 1, 1, '', 0)
+      `);
+      database.close();
+
+      const result = await getBrowserCookies({
+        url: "https://example.com/",
+        inlineCookiesJson: JSON.stringify({
+          cookies: [
+            {
+              name: "opaque-without-key",
+              value: "synthetic",
+              domain: "example.com",
+              partitionKeyOpaque: true,
+            },
+            {
+              name: "opaque-with-null-key",
+              value: "synthetic",
+              domain: "example.com",
+              partitionKey: null,
+              partitionKeyOpaque: true,
+            },
+          ],
+        }),
+        browsers: ["firefox"],
+        firefoxProfile: profile,
+      });
+
+      expect(result.cookies).toEqual([]);
+      expect(result.warnings).toEqual([
+        "2 inline cookie(s) with partition or container provenance were excluded because replay cannot preserve their isolation context.",
+      ]);
+    } finally {
+      try {
+        database.close();
+      } catch {
+        // The happy path closes before the provider could inspect the synthetic profile.
+      }
+      rmSync(profile, { recursive: true, force: true });
+    }
+  });
+
   test("enforces host/domain, request path, Secure, expiry, and syntax", () => {
     const result = filterCookieProviderResult({
       cookies: [
@@ -186,8 +246,11 @@ describe("strict browser-like cookie filtering", () => {
         { name: "ambiguous-parent", value: "no", domain: "example.com", path: "/account" },
         { name: "unproven-exact", value: "no", domain: "sub.example.com", path: "/account" },
         { name: "explicit-parent", value: "yes", domain: "example.com", hostOnly: false, path: "/account" },
-        { name: "exact-host", value: "yes", domain: "sub.example.com", hostOnly: true, path: "/account" },
+        { name: "exact-host", value: "yes", domain: "sub.example.com", hostOnly: true, path: "/account", partitionKeyOpaque: false },
         { name: "partitioned", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", partitioned: true },
+        { name: "opaque", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", partitionKeyOpaque: true },
+        { name: "opaque-null-key", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", partitionKey: null, partitionKeyOpaque: true },
+        { name: "malformed-opaque", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", partitionKeyOpaque: "false" },
         { name: "container", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", originAttributes: "^userContextId=2" },
         { name: "object-partition", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", partitionKey: { topLevelSite: "https://attacker.example" } },
         { name: "malformed-top-frame", value: "no", domain: "sub.example.com", hostOnly: true, path: "/account", top_frame_site_key: 0 },
@@ -196,7 +259,7 @@ describe("strict browser-like cookie filtering", () => {
       warnings: [],
     }, target);
 
-    expect(result.rejected).toBe(7);
+    expect(result.rejected).toBe(10);
     expect(result.cookies).toEqual([
       expect.objectContaining({ name: "exact-host", domain: "sub.example.com", hostOnly: true }),
       expect.objectContaining({ name: "explicit-parent", domain: "example.com", hostOnly: false }),
@@ -260,6 +323,32 @@ describe("explicit cookie payload formats", () => {
     expect(domainless.ok && domainless.scopeProvenance).toBe("target-inferred");
     expect(header.ok && header.scopeProvenance).toBe("target-inferred");
   });
+
+  test.each(["json", "base64-json"] as const)(
+    "fails closed on opaque partition provenance in explicit %s payloads",
+    (format) => {
+      const records = [
+        { ...cookie, name: "missing-marker" },
+        { ...cookie, name: "explicit-false", partitionKeyOpaque: false },
+        { ...cookie, name: "opaque-without-key", partitionKeyOpaque: true },
+        { ...cookie, name: "opaque-with-null-key", partitionKey: null, partitionKeyOpaque: true },
+        { ...cookie, name: "malformed-marker", partitionKeyOpaque: "false" },
+      ];
+      const json = JSON.stringify({ cookies: records });
+      const input = format === "json" ? json : Buffer.from(json).toString("base64");
+      const parsed = parseCookiePayload(input, target, 1_700_000_000);
+
+      expect(parsed.ok).toBeTrue();
+      if (!parsed.ok) return;
+      expect(parsed.format).toBe(format);
+      expect(parsed.scopeProvenance).toBe("explicit");
+      expect(parsed.rejected).toBe(3);
+      expect(parsed.cookies.map(({ name }) => name)).toEqual([
+        "explicit-false",
+        "missing-marker",
+      ]);
+    },
+  );
 
   test("rejects empty, malformed, and entirely out-of-scope input", () => {
     expect(parseCookiePayload("not cookies", target)).toEqual({ ok: false, reason: "invalid" });

--- a/src/clip/cookies.ts
+++ b/src/clip/cookies.ts
@@ -157,7 +157,7 @@ function hasSafeUnpartitionedProvenance(value: CandidateCookie): boolean {
     if (provenance === undefined || provenance === null) continue;
     if (typeof provenance !== "string" || provenance.trim() !== "") return false;
   }
-  for (const field of ["partitioned"] as const) {
+  for (const field of ["partitioned", "partitionKeyOpaque"] as const) {
     const flag = value[field];
     if (flag === undefined || flag === null) continue;
     if (typeof flag !== "boolean" || flag) return false;

--- a/src/clip/doctor.test.ts
+++ b/src/clip/doctor.test.ts
@@ -35,7 +35,7 @@ describe("clip doctor", () => {
         dependencies: {
           defuddle: "^0.19.1",
           "agent-browser": "0.32.3",
-          "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.2",
+          "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
           "@tobilu/qmd": "2.5.3",
         },
       })],
@@ -43,7 +43,7 @@ describe("clip doctor", () => {
       [join(consumerRoot, "node_modules", "agent-browser", "package.json"), packageManifest("agent-browser", "0.32.3")],
       [
         join(consumerRoot, "node_modules", "@steipete", "sweet-cookie", "package.json"),
-        packageManifest("@steipete/sweet-cookie", "0.4.2"),
+        packageManifest("@steipete/sweet-cookie", "0.4.4"),
       ],
       [join(qmdRoot, "package.json"), packageManifest("@tobilu/qmd", "2.5.3")],
       [join(qmdRoot, "node_modules", "sqlite-vec", "package.json"), packageManifest("sqlite-vec", "0.1.9")],
@@ -138,13 +138,13 @@ describe("clip doctor", () => {
     });
     expect(report.dependencies.find(({ name }) => name === "@steipete/sweet-cookie")).toEqual({
       name: "@steipete/sweet-cookie",
-      expectedVersion: "0.4.2",
-      declaredVersion: "github:hraness/sweet-cookie#v0.4.2",
-      installedVersion: "0.4.2",
+      expectedVersion: "0.4.4",
+      declaredVersion: "github:hraness/sweet-cookie#v0.4.4",
+      installedVersion: "0.4.4",
       status: "ready",
     });
     expect(renderDoctorReport(report)).toContain(
-      "@steipete/sweet-cookie: ready (declared github:hraness/sweet-cookie#v0.4.2; installed 0.4.2; expected 0.4.2)",
+      "@steipete/sweet-cookie: ready (declared github:hraness/sweet-cookie#v0.4.4; installed 0.4.4; expected 0.4.4)",
     );
     expect(report.search.keywordOnly).toEqual({ status: "ready", modelRequired: false });
     expect(report.search.semanticPrerequisites).toMatchObject({

--- a/src/clip/doctor.ts
+++ b/src/clip/doctor.ts
@@ -142,7 +142,7 @@ type JsonRecord = Readonly<Record<string, unknown>>;
 const dependencyVersions = {
   "defuddle": "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.2",
+  "@steipete/sweet-cookie": "0.4.4",
   "@tobilu/qmd": expectedQmdVersion,
 } as const satisfies Readonly<Record<DependencyReport["name"], string>>;
 const dependencyNames: readonly DependencyReport["name"][] = [


### PR DESCRIPTION
## Summary

- pin the immutable Hraness Sweet Cookie v0.4.4 release
- reject opaque partition provenance across provider, JSON, and base64 cookie inputs
- add synthetic installed-provider fallback coverage and prepare KB v0.19.1 release identity
- regenerate canonical dist and reseal the reviewed 204-file package inventory

## Validation

- focused: 114 pass, 0 fail, 1,395 assertions
- typecheck: green
- canonical `bun run check`: 1,249 pass, 0 fail, 12,908 assertions; package smoke and Rust metadata tool check green
- reviewed package identity: 204 files, 4,981,223 unpacked bytes
- independent source/generated/release review: no P0-P2 findings

All cookie fixtures are synthetic; no user browser profile, cookie store, or Keychain was accessed.