### PR TITLE
Fix npm 11.19 attestation verification for v0.19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global @hraness/kb@0.19.1
+bun add --global @hraness/kb@0.19.2
 kb --help
 ```
 
@@ -260,9 +260,9 @@ Treat the knowledge base as repository-adjacent durable memory. Authored Markdow
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.19.1` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.19.2` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
-`@hraness/kb@0.19.1` registry release only when the command is missing. Verify it
+`@hraness/kb@0.19.2` registry release only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
 I ask.
 ```
@@ -270,25 +270,25 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.19.1
-bunx skills add hraness/kb#v0.19.1
+npx skills add hraness/kb#v0.19.2
+bunx skills add hraness/kb#v0.19.2
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
 agent runner. Skill installation is inert: it does not initialize a vault,
 refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 `kb` command or, when the command is missing, checks for Bun and installs the
-CLI from the immutable `@hraness/kb@0.19.1` npm version.
+CLI from the immutable `@hraness/kb@0.19.2` npm version.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.19.1` npm package includes the same tree under
+`0.19.2` npm package includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global @hraness/kb@0.19.1
+bun add --global @hraness/kb@0.19.2
 kb --help
 kb-evaluation-builder --help
 ```
@@ -296,7 +296,7 @@ kb-evaluation-builder --help
 The same registry package can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts @hraness/kb@0.19.1
+npm install --global --ignore-scripts @hraness/kb@0.19.2
 kb --help
 ```
 
@@ -309,7 +309,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the exact npm version to a Bun project:
 
 ```sh
-bun add --exact @hraness/kb@0.19.1
+bun add --exact @hraness/kb@0.19.2
 ```
 
 The resulting dependency should remain exact:
@@ -317,12 +317,12 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "0.19.1"
+    "@hraness/kb": "0.19.2"
   }
 }
 ```
 
-Version 0.19.1 retains three public GitHub dependencies: `@hraness/oh` at
+Version 0.19.2 retains three public GitHub dependencies: `@hraness/oh` at
 immutable release `v0.2.0` for closure verification,
 `@steipete/sweet-cookie` at Hraness release `v0.4.4` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
@@ -593,9 +593,9 @@ ritual. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.19.1
+npx skills add hraness/kb#v0.19.2
 # or
-bunx skills add hraness/kb#v0.19.1
+bunx skills add hraness/kb#v0.19.2
 ```
 
 The skill invokes the installed `kb` command without depending on a repository
@@ -609,6 +609,13 @@ discovery omits it.
 See [Design](docs/design.md), [Portfolio federation](docs/portfolio.md), [Agent workflow](docs/agent-workflow.md), [PDF capture](docs/pdf.md), and [Contributing](CONTRIBUTING.md) for the durable contracts and development gate. hraness/kb is available under the [MIT License](LICENSE).
 
 ## Release notes
+
+### Upgrade to v0.19.2
+
+Version 0.19.2 recognizes npm 11.19's `signedAccessSignatureUrl` attestation
+wrapper field only when it is the currently evidenced empty string. Exact-key,
+signature, package, workflow, source, and provenance verification remain
+mandatory. Package runtime behavior is unchanged.
 
 ### Upgrade to v0.19.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.19.1"
+      "version": "0.19.2"
     }
   ],
   "dependencies": [

--- a/scripts/kb-skill-contract.test.ts
+++ b/scripts/kb-skill-contract.test.ts
@@ -191,7 +191,7 @@ test("the shipped skill resources preserve routing and companion contracts", asy
     "references/url-platforms.md",
     "templates/companion-skill.template.md",
   ]);
-  expect(manifest.version).toBe("0.19.1");
+  expect(manifest.version).toBe("0.19.2");
   expect(manifestFiles).toContain("skills/kb");
   expect(publicSourceFiles).toContain("src/repository-memory.ts");
   expect(Object.keys(manifest.exports as Record<string, unknown>).toSorted()).toEqual([

--- a/scripts/kb-skill-contract.ts
+++ b/scripts/kb-skill-contract.ts
@@ -418,8 +418,8 @@ export function validateKbSkillContractResources(
       errors.push(`SKILL.md must link ${link}`);
     }
   }
-  if (!resources.skill.includes("bun add --global @hraness/kb@0.19.1")) {
-    errors.push("SKILL.md must retain the immutable 0.19.1 runtime pin");
+  if (!resources.skill.includes("bun add --global @hraness/kb@0.19.2")) {
+    errors.push("SKILL.md must retain the immutable 0.19.2 runtime pin");
   }
   for (const [name, contents, headings] of [
     ["customize.md", resources.customize, CUSTOMIZE_HEADINGS],

--- a/scripts/npm-release-attestation.test.ts
+++ b/scripts/npm-release-attestation.test.ts
@@ -31,6 +31,7 @@ function bundle(
   const keyid = publish ? "SHA256:test-key" : "";
   return {
     predicateType,
+    signedAccessSignatureUrl: "",
     bundle: {
       mediaType,
       verificationMaterial: {
@@ -151,6 +152,17 @@ function statement(
   input: Fixture,
   expectedPredicateType: string,
 ): Record<string, unknown> {
+  const candidate = attestationBundle(input, expectedPredicateType);
+  const envelope = record(record(candidate.bundle, "bundle").dsseEnvelope, "envelope");
+  const payload = envelope.payload;
+  if (typeof payload !== "string") throw new TypeError("payload must be a string");
+  return record(JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as unknown, "statement");
+}
+
+function attestationBundle(
+  input: Fixture,
+  expectedPredicateType: string,
+): Record<string, unknown> {
   const verified = verifiedRecord(input);
   const bundles = verified.attestationBundles;
   if (!Array.isArray(bundles)) throw new TypeError("attestationBundles must be an array");
@@ -158,10 +170,7 @@ function statement(
     .map((value) => record(value, "attestation bundle"))
     .find((value) => value.predicateType === expectedPredicateType);
   if (candidate === undefined) throw new TypeError("attestation bundle is missing");
-  const envelope = record(record(candidate.bundle, "bundle").dsseEnvelope, "envelope");
-  const payload = envelope.payload;
-  if (typeof payload !== "string") throw new TypeError("payload must be a string");
-  return record(JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as unknown, "statement");
+  return candidate;
 }
 
 function replaceStatement(
@@ -198,6 +207,49 @@ describe("npm release attestation", () => {
       tarballSha512,
       version,
     });
+  });
+
+  test("accepts only npm's currently evidenced empty signed access signature URL", () => {
+    const corruptions: readonly Readonly<{
+      label: string;
+      mutate: (attestation: Record<string, unknown>) => void;
+    }>[] = [
+      {
+        label: "missing signed access signature URL",
+        mutate: (attestation) => {
+          delete attestation.signedAccessSignatureUrl;
+        },
+      },
+      {
+        label: "non-string signed access signature URL",
+        mutate: (attestation) => {
+          attestation.signedAccessSignatureUrl = 0;
+        },
+      },
+      {
+        label: "nonempty signed access signature URL",
+        mutate: (attestation) => {
+          attestation.signedAccessSignatureUrl = "https://registry.example/signature";
+        },
+      },
+      {
+        label: "unknown attestation wrapper key",
+        mutate: (attestation) => {
+          attestation.unexpected = true;
+        },
+      },
+    ];
+
+    for (const predicateType of [publishPredicateType, provenancePredicateType]) {
+      for (const corruption of corruptions) {
+        const input = structuredClone(validInput());
+        corruption.mutate(attestationBundle(input, predicateType));
+        expect(
+          () => verifyNpmReleaseAttestation(input),
+          `${predicateType}: ${corruption.label}`,
+        ).toThrow();
+      }
+    }
   });
 
   test("rejects identity, provenance, publication, signature, and channel drift", () => {

--- a/scripts/npm-release-attestation.ts
+++ b/scripts/npm-release-attestation.ts
@@ -157,9 +157,19 @@ function decodeStatement(
   mediaType: string,
 ): Record<string, unknown> {
   const attestation = record(value, `${predicateType} attestation`);
-  exactKeys(attestation, ["bundle", "predicateType"], `${predicateType} attestation`);
+  exactKeys(
+    attestation,
+    ["bundle", "predicateType", "signedAccessSignatureUrl"],
+    `${predicateType} attestation`,
+  );
   if (attestation.predicateType !== predicateType) {
     throw new TypeError(`${predicateType} attestation has the wrong predicate type`);
+  }
+  if (
+    typeof attestation.signedAccessSignatureUrl !== "string"
+    || attestation.signedAccessSignatureUrl !== ""
+  ) {
+    throw new TypeError(`${predicateType} attestation signed access signature URL must be empty`);
   }
   const bundle = record(attestation.bundle, `${predicateType} bundle`);
   exactKeys(

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -385,7 +385,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.19.1",
+      version: "0.19.2",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",
@@ -1980,7 +1980,7 @@ describe("canonical npm package identity", () => {
       });
       const verified = await verifyNpmPackageIdentity(validInput);
       expect(verified.fileCount).toBe(204);
-      expect(verified.unpackedBytes).toBe(4_981_223);
+      expect(verified.unpackedBytes).toBe(4_981_527);
       expect(verified.sourceArchiveSha512).not.toBe(verified.registryArchiveSha512);
 
       const originalTar = gunzipSync(sourceBytes);

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -55,7 +55,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global @hraness/kb@0.19.1
+  bun add --global @hraness/kb@0.19.2
 }
 kb --help
 ```


### PR DESCRIPTION
Summary:
- admit npm 11.19 signedAccessSignatureUrl only when it is the evidenced empty string
- retain exact-key fail-closed validation for missing, mistyped, nonempty, and unknown wrapper fields
- advance canonical package, skill, inventory, README, and release-test surfaces to stable 0.19.2 while preserving 0.19.1 history

Validation:
- Bun 1.3.14 frozen script-disabled install; bun.lock unchanged
- focused release-workflow and attestation tests: 24 passed, 450 assertions
- full bun run check through hra-host-run with npm 11.19.0: 1,250 tests passed, 0 failed; workflow, inventory, docs, typecheck, build, package identity, and Rust metadata-tool checks green

This PR does not stage, publish, tag, or merge the release.