### PR TITLE
fix(release): admit exact GitHub draft asset URLs for 0.19.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz
+bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
 kb --help
 ```
 
@@ -253,14 +253,14 @@ Treat the knowledge base as repository-adjacent durable memory. Authored Markdow
 
 ## Installation reference
 
-[Bun](https://bun.sh/docs/installation) is the required runtime. GitHub Releases are the canonical distribution; npm is an optional mirror. The examples target the prepared `0.19.4` release and become available when its GitHub release is published. Existing `0.19.2` npm installs remain available during that transition. For signed artifact verification, see [the release procedure](docs/publishing.md#verify-a-published-release).
+[Bun](https://bun.sh/docs/installation) is the required runtime. GitHub Releases are the canonical distribution; npm is an optional mirror. The examples target the prepared `0.19.5` release and become available when its GitHub release is published. Existing `0.19.2` npm installs remain available during that transition. For signed artifact verification, see [the release procedure](docs/publishing.md#verify-a-published-release).
 
 ### Tell your coding agent to install it
 
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.19.4` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.19.5` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
 versioned GitHub release archive only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
@@ -270,8 +270,8 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.19.4
-bunx skills add hraness/kb#v0.19.4
+npx skills add hraness/kb#v0.19.5
+bunx skills add hraness/kb#v0.19.5
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
@@ -281,14 +281,14 @@ refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 CLI from the immutable GitHub release archive.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.19.4` packed release includes the same tree under
+`0.19.5` packed release includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz
+bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
 kb --help
 kb-evaluation-builder --help
 ```
@@ -296,7 +296,7 @@ kb-evaluation-builder --help
 The same GitHub archive can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz
+npm install --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
 kb --help
 ```
 
@@ -309,7 +309,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the versioned GitHub archive to a Bun project:
 
 ```sh
-bun add --exact --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz
+bun add --exact --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
 ```
 
 The resulting dependency should remain exact:
@@ -317,12 +317,12 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz"
+    "@hraness/kb": "https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz"
   }
 }
 ```
 
-Version 0.19.4 retains three public GitHub dependencies: `@hraness/oh` at
+Version 0.19.5 retains three public GitHub dependencies: `@hraness/oh` at
 immutable release `v0.2.0` for closure verification,
 `@steipete/sweet-cookie` at Hraness release `v0.4.4` for the cookie-scope safety
 fork, and `@tobilu/qmd` at commit
@@ -592,9 +592,9 @@ ritual. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.19.4
+npx skills add hraness/kb#v0.19.5
 # or
-bunx skills add hraness/kb#v0.19.4
+bunx skills add hraness/kb#v0.19.5
 ```
 
 The skill invokes the installed `kb` command without depending on a repository
@@ -609,7 +609,13 @@ See [Design](docs/design.md), [Portfolio federation](docs/portfolio.md), [Agent 
 
 ## Release notes
 
-### Upgrade to v0.19.4
+### Upgrade to v0.19.5
+
+This candidate corrects draft asset URL admission before the first canonical
+GitHub package release. GitHub may expose a temporary same-repository URL until
+the draft is published; published assets still require their exact versioned
+URLs and verified bytes. The failed `v0.19.4` draft is retained as release
+evidence and is not an installable release.
 
 GitHub Releases become the canonical installation source. Each release binds its packed archive to the reviewed source and signed GitHub build identity. npm remains an optional mirror and older installations keep working. The SDK and CLI interfaces do not change.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,6 +1,8 @@
 # Publish KB
 
-GitHub Releases are canonical from `0.19.4`. Each immutable release contains
+The canonical artifact contract starts at `0.19.4`; that first attempt stopped
+with a retained partial draft. The prepared `0.19.5` candidate is not installable
+until its immutable release completes. Each successful release contains
 one checked package archive, its packing receipt, a source/run manifest,
 checksums, and signed GitHub provenance. npm is an optional mirror of those
 exact archive bytes. An npm outage or pending npm promotion does not block a
@@ -78,7 +80,11 @@ authorizes creating another release. Publication uploads only missing matching a
 provider asset names, sizes, SHA-256 digests, and Actions-bot creator
 `41898282`, then downloads each exact asset ID and checks its bytes before
 publishing an immutable Latest release. It repeats the exact asset-byte readback
-after publication. Current main,
+after publication. Draft descriptors may use the exact versioned URL or a
+same-repository `untagged-` URL with exactly twenty lowercase hexadecimal digits
+and the exact asset name. Published descriptors require the versioned URL.
+These browser URLs never carry authenticated downloads; those use the exact
+GitHub API asset ID. Current main,
 annotated tag, source ancestry, and the complete helper/workflow closure are
 revalidated before each mutation. Existing matching state is reconciled;
 assets are never overwritten and releases are never deleted/recreated.
@@ -133,7 +139,7 @@ gh workflow run npm-stage.yml --ref main -f publish_to_npm=true
 ```
 
 The default candidate is current main's package version. To mirror an earlier
-canonical release while GitHub is ahead, add `-f release_tag=v0.19.4`. The input
+canonical release while GitHub is ahead, add `-f release_tag=v0.19.5`. The input
 must be one exact stable tag no newer than current main's version; its source
 must be an ancestor of the workflow commit, and its version must still be newer
 than npm `latest`. Neither a Git branch with a matching name nor an unqualified
@@ -178,3 +184,18 @@ dispatch. Leave that input empty normally. It records resolution for only the
 matching durable intent; it cannot clear another version or an unresolved
 provider write. This is not a claim that npm exposes or prevents an
 out-of-band concurrent stage.
+
+## Retained v0.19.4 publication failure
+
+[Release run 34353781377](https://github.com/hraness/kb/actions/runs/34353781377)
+verified source, packed bytes and attestation, then stopped after uploading
+`SHA256SUMS` to draft `385518557`. The descriptor used GitHub's temporary
+`untagged-ef6c1bd779e9dd4032bb` path; the original verifier required a published
+tag path even for a draft. Asset `552772852` is 256 bytes with SHA-256
+`7439c234c0a6d0166efef952e3d8ee76dfde2178934ffe8dcdebb84cd1dfe162`.
+
+Preserve that tag, draft, uploaded asset and original attested evidence. It is
+not an admitted public release and must not be retried under changed source,
+overwritten, relabeled or deleted. The `0.19.5` candidate applies the reviewed
+state-aware descriptor rule while retaining exact IDs, bytes, source and
+provenance admission. Its install examples remain conditional until publication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.19.4"
+      "version": "0.19.5"
     }
   ],
   "dependencies": [

--- a/scripts/github-release.test.ts
+++ b/scripts/github-release.test.ts
@@ -82,6 +82,31 @@ test("draft recovery only admits matching existing assets and published releases
   expect(() => verifyProviderRelease({ ...release, draft: false, immutable: true }, manifest, assets, false)).toThrow("missing canonical assets");
 });
 
+test("temporary draft asset URLs remain same-repository and never admit published assets", () => {
+  const temporaryUrl = "https://github.com/hraness/kb/releases/download/untagged-ef6c1bd779e9dd4032bb/SHA256SUMS";
+  const sha256 = "7439c234c0a6d0166efef952e3d8ee76dfde2178934ffe8dcdebb84cd1dfe162";
+  const assets = [{ name: "SHA256SUMS", bytes: 256, sha256 }];
+  const asset = { id: 552772852, name: "SHA256SUMS", size: 256, digest: `sha256:${sha256}`, state: "uploaded",
+    browser_download_url: temporaryUrl, url: "https://api.github.com/repos/hraness/kb/releases/assets/552772852" };
+  const draft = { id: 385518557, tag_name: manifest.tag, target_commitish: manifest.sourceSha, name: `KB ${manifest.tag}`,
+    body: releaseBody(manifest), draft: true, immutable: false, prerelease: false,
+    author: { id: 41898282, login: "github-actions[bot]", type: "Bot" }, assets: [asset] };
+  expect(verifyProviderRelease(draft, manifest, assets, true)).toEqual([]);
+  for (const url of [
+    temporaryUrl.replace("hraness/kb", "other/kb"), temporaryUrl.replace("SHA256SUMS", "npm-pack.json"),
+    temporaryUrl.replace("ef6c1bd779e9dd4032bb", "ef6c1bd779e9dd4032b"),
+    temporaryUrl.replace("ef6c1bd779e9dd4032bb", "EF6C1BD779E9DD4032BB"),
+    `${temporaryUrl}?token=anything`, `${temporaryUrl}#fragment`, temporaryUrl.replace("untagged-", "refs/untagged-"),
+  ]) expect(() => verifyProviderRelease({ ...draft, assets: [{ ...asset, browser_download_url: url }] }, manifest, assets, true)).toThrow();
+  for (const allowDraft of [true, false]) {
+    expect(() => verifyProviderRelease({ ...draft, draft: false, immutable: true }, manifest, assets, allowDraft)).toThrow();
+  }
+  fc.assert(fc.property(fc.array(fc.constantFrom(..."0123456789abcdef"), { minLength: 20, maxLength: 20 }), (digits) => {
+    const url = `https://github.com/hraness/kb/releases/download/untagged-${digits.join("")}/SHA256SUMS`;
+    expect(verifyProviderRelease({ ...draft, assets: [{ ...asset, browser_download_url: url }] }, manifest, assets, true)).toEqual([]);
+  }));
+});
+
 test("verified certificate and subject bind repository, source, workflow, hosted runner, and exact attempt", () => {
   const uri = `https://github.com/hraness/kb/.github/workflows/release.yml@refs/tags/${manifest.tag}`;
   const certificate = {
@@ -122,7 +147,7 @@ test("draft publication survives by-tag 404 through one retained release ID with
     .map((name) => ({ name, bytes: remoteBytes.length, sha256: digest(remoteBytes) }));
   const descriptor = (name: string, id: number) => ({
     id, name, size: remoteBytes.length, digest: `sha256:${digest(remoteBytes)}`, state: "uploaded",
-    browser_download_url: `https://github.com/hraness/kb/releases/download/${manifest.tag}/${name}`,
+    browser_download_url: `https://github.com/hraness/kb/releases/download/untagged-ef6c1bd779e9dd4032bb/${name}`,
     url: `https://api.github.com/repos/hraness/kb/releases/assets/${id}`,
   });
   const fixture = (existing: boolean, conflict = false, fault?: "bytes" | "id" | "published-bytes" | "creation-status" | "creation-identity") => {
@@ -169,6 +194,7 @@ test("draft publication survives by-tag 404 through one retained release ID with
         expect(args).toContain("draft=false");
         expect(args).toContain("make_latest=true");
         release.draft = false; release.immutable = true;
+        for (const asset of release.assets) asset.browser_download_url = `https://github.com/hraness/kb/releases/download/${manifest.tag}/${asset.name}`;
         return JSON.stringify(release);
       }
       if (args[2] === "GET" && endpoint === `/repos/hraness/kb/releases/tags/${manifest.tag}` && release.draft) {

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -125,6 +125,15 @@ export function releaseBody(manifest: ReleaseManifest): string {
 
 export type AssetIdentity = Readonly<{ name: string; bytes: number; sha256: string }>;
 
+function exactAssetBrowserUrl(value: unknown, name: string, tag: string, draft: boolean): boolean {
+  const prefix = `https://github.com/${repository}/releases/download/`;
+  if (value === `${prefix}${tag}/${name}`) return true;
+  if (!draft || typeof value !== "string" || !value.startsWith(`${prefix}untagged-`)
+    || !value.endsWith(`/${name}`)) return false;
+  const temporaryId = value.slice(`${prefix}untagged-`.length, -(`/${name}`.length));
+  return /^[a-f0-9]{20}$/u.test(temporaryId);
+}
+
 export function verifyProviderRelease(value: unknown, manifest: ReleaseManifest, assets: readonly AssetIdentity[], allowDraft: boolean): readonly string[] {
   const release = record(value, "GitHub Release");
   const author = record(release.author, "Release author");
@@ -142,7 +151,7 @@ export function verifyProviderRelease(value: unknown, manifest: ReleaseManifest,
     const expected = assets.find((candidate) => candidate.name === asset.name);
     if (expected === undefined || present.has(expected.name) || asset.size !== expected.bytes
       || asset.digest !== `sha256:${expected.sha256}` || asset.state !== "uploaded"
-      || asset.browser_download_url !== `https://github.com/${repository}/releases/download/${manifest.tag}/${expected.name}`
+      || !exactAssetBrowserUrl(asset.browser_download_url, expected.name, manifest.tag, release.draft === true)
       || asset.url !== `https://api.github.com/repos/${repository}/releases/assets/${String(asset.id)}`) {
       throw new Error("GitHub release has an unexpected, duplicate, or mismatched asset");
     }

--- a/scripts/kb-skill-contract.test.ts
+++ b/scripts/kb-skill-contract.test.ts
@@ -191,7 +191,7 @@ test("the shipped skill resources preserve routing and companion contracts", asy
     "references/url-platforms.md",
     "templates/companion-skill.template.md",
   ]);
-  expect(manifest.version).toBe("0.19.4");
+  expect(manifest.version).toBe("0.19.5");
   expect(manifestFiles).toContain("skills/kb");
   expect(publicSourceFiles).toContain("src/repository-memory.ts");
   expect(Object.keys(manifest.exports as Record<string, unknown>).toSorted()).toEqual([

--- a/scripts/kb-skill-contract.ts
+++ b/scripts/kb-skill-contract.ts
@@ -418,8 +418,8 @@ export function validateKbSkillContractResources(
       errors.push(`SKILL.md must link ${link}`);
     }
   }
-  if (!resources.skill.includes("bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz")) {
-    errors.push("SKILL.md must retain the immutable 0.19.4 GitHub runtime pin");
+  if (!resources.skill.includes("bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz")) {
+    errors.push("SKILL.md must retain the immutable 0.19.5 GitHub runtime pin");
   }
   for (const [name, contents, headings] of [
     ["customize.md", resources.customize, CUSTOMIZE_HEADINGS],

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -383,7 +383,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.19.4",
+      version: "0.19.5",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -55,7 +55,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.4/hraness-kb-0.19.4.tgz
+  bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
 }
 kb --help
 ```


### PR DESCRIPTION
GitHub assigned the v0.19.4 draft's uploaded `SHA256SUMS` a temporary `untagged-…` download URL, causing publication to stop even though its exact asset ID, size, and digest matched. Accept that provider URL only for an actual draft, with the same repository, exactly 20 lowercase hexadecimal characters, and the exact admitted asset name. Published releases still require the canonical version-tag URL; authenticated downloads continue to use numeric asset IDs and verify the bytes before publication and after immutable readback.

Prepare v0.19.5 and update current install examples conditionally. Preserve the failed v0.19.4 tag, draft, asset, and provenance for reconciliation, and retain the canonical format boundary at v0.19.4. Package runtime, dependencies, committed builds, and optional npm stage controls remain unchanged.

Validation: frozen dependency installation and the complete `bun run check` gate passed, including 1,311 source tests, package installation/smoke, and the Rust tool check. Committed `dist/` and `bun.lock` remain unchanged. Focused publisher/skill/README checks passed (22 tests, 589 assertions), including the observed provider descriptor, draft-to-published URL transition, malformed URLs, and rejection of temporary URLs for published releases. The first full gate identified one stale current-version expectation; it was corrected and its focused test passed. Root and an independent peer reviewed the change.
