### PR TITLE
Adopt upstream Sweet Cookie 0.4.3 for KB 0.19.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ system.
 Bun 1.3.14 or newer is required.
 
 ```sh
-bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
+bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz
 kb --help
 ```
 
@@ -253,14 +253,14 @@ Treat the knowledge base as repository-adjacent durable memory. Authored Markdow
 
 ## Installation reference
 
-[Bun](https://bun.sh/docs/installation) is the required runtime. GitHub Releases are the canonical distribution; npm is an optional mirror. The examples target the prepared `0.19.5` release and become available when its GitHub release is published. Existing `0.19.2` npm installs remain available during that transition. For signed artifact verification, see [the release procedure](docs/publishing.md#verify-a-published-release).
+[Bun](https://bun.sh/docs/installation) is the required runtime. GitHub Releases are the canonical distribution; npm is an optional mirror. The examples target the prepared `0.19.6` release and become available when its GitHub release is published. Existing `0.19.2` npm installs remain available during that transition. For signed artifact verification, see [the release procedure](docs/publishing.md#verify-a-published-release).
 
 ### Tell your coding agent to install it
 
 Copy this prompt into Codex, Claude Code, or another coding agent:
 
 ```text
-Install the `kb` Agent Skill from `hraness/kb#v0.19.5` with the standard skills
+Install the `kb` Agent Skill from `hraness/kb#v0.19.6` with the standard skills
 CLI. Use the skill's runtime instructions to install the exact
 versioned GitHub release archive only when the command is missing. Verify it
 with `kb doctor` and `kb --help`, but do not initialize or modify a vault until
@@ -270,8 +270,8 @@ I ask.
 Install the single public skill with either runner:
 
 ```sh
-npx skills add hraness/kb#v0.19.5
-bunx skills add hraness/kb#v0.19.5
+npx skills add hraness/kb#v0.19.6
+bunx skills add hraness/kb#v0.19.6
 ```
 
 Both commands discover the same `kb` skill and install it into the selected
@@ -281,14 +281,14 @@ refresh a catalog, or edit Markdown. When invoked, the skill uses an existing
 CLI from the immutable GitHub release archive.
 
 The public skills CLI reads `skills/kb/` from the repository. The immutable
-`0.19.5` packed release includes the same tree under
+`0.19.6` packed release includes the same tree under
 `node_modules/@hraness/kb/skills/kb/`, and the package check verifies that the
 installed skill is byte-identical to the repository source.
 
 Install the two global commands with Bun:
 
 ```sh
-bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
+bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz
 kb --help
 kb-evaluation-builder --help
 ```
@@ -296,7 +296,7 @@ kb-evaluation-builder --help
 The same GitHub archive can be installed with npm:
 
 ```sh
-npm install --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
+npm install --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz
 kb --help
 ```
 
@@ -309,7 +309,7 @@ reviewed and enabled; run `kb doctor` to inspect the resulting capabilities.
 For programmatic use, add the versioned GitHub archive to a Bun project:
 
 ```sh
-bun add --exact --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
+bun add --exact --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz
 ```
 
 The resulting dependency should remain exact:
@@ -317,18 +317,18 @@ The resulting dependency should remain exact:
 ```json
 {
   "dependencies": {
-    "@hraness/kb": "https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz"
+    "@hraness/kb": "https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz"
   }
 }
 ```
 
-Version 0.19.5 retains three public GitHub dependencies: `@hraness/oh` at
-immutable release `v0.2.0` for closure verification,
-`@steipete/sweet-cookie` at Hraness release `v0.4.4` for the cookie-scope safety
-fork, and `@tobilu/qmd` at commit
-`aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior. Installation also needs Git and public GitHub access while it
-resolves those dependencies. They remain part of this release's supported
-installation contract until equivalent registry releases are available.
+Version 0.19.6 retains two public GitHub dependencies: `@hraness/oh` at
+immutable release `v0.2.0` for closure verification and `@tobilu/qmd` at commit
+`aa993dceb3ef8cfb71d470554ca437570f5a2b3c` for store-local model behavior.
+Installation also needs Git and public GitHub access while it resolves those
+dependencies. Browser-cookie capture uses the exact upstream registry release
+`@steipete/sweet-cookie` `0.4.3`, which includes the host-scope, isolation, and
+explicit Chromium Keychain fixes previously carried by the Hraness fork.
 
 ### Review lifecycle scripts before enabling optional adapters
 
@@ -592,9 +592,9 @@ ritual. The package smoke test keeps future tagged packages byte-identical to
 that source tree.
 
 ```sh
-npx skills add hraness/kb#v0.19.5
+npx skills add hraness/kb#v0.19.6
 # or
-bunx skills add hraness/kb#v0.19.5
+bunx skills add hraness/kb#v0.19.6
 ```
 
 The skill invokes the installed `kb` command without depending on a repository
@@ -608,6 +608,15 @@ discovery omits it.
 See [Design](docs/design.md), [Portfolio federation](docs/portfolio.md), [Agent workflow](docs/agent-workflow.md), [PDF capture](docs/pdf.md), and [Contributing](CONTRIBUTING.md) for the durable contracts and development gate. hraness/kb is available under the [MIT License](LICENSE).
 
 ## Release notes
+
+### Upgrade to v0.19.6
+
+Version 0.19.6 adopts the upstream Sweet Cookie 0.4.3 registry package in place
+of the Hraness 0.4.4 fork. Upstream includes the cookie-scope, isolation, and
+explicit Chromium Keychain fixes. Capture retains host-only and Domain cookie
+scope, rejects partitioned or container state it cannot replay, and keeps
+explicit browser selection bound to its profile. The local cookie guards and
+synthetic provider regressions remain in place.
 
 ### Upgrade to v0.19.5
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@hraness/kb",
       "dependencies": {
         "@hraness/oh": "github:hraness/oh#v0.2.0",
-        "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
+        "@steipete/sweet-cookie": "0.4.3",
         "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
         "agent-browser": "0.32.3",
         "defuddle": "0.19.1",
@@ -94,7 +94,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@github:hraness/sweet-cookie#1a8b6f0", { "bin": { "sweet-cookie": "packages/core/dist/cli.js" } }, "hraness-sweet-cookie-1a8b6f0", "sha512-gL+Gu9WsBbE0Xk1xaXOYESKChl0y8HEGYl7Oi8c4MhR0Q+Tu8YjqVQi8hk/sOg5wL6gddUcpz7sGn8augLNUFw=="],
+    "@steipete/sweet-cookie": ["@steipete/sweet-cookie@0.4.3", "", { "bin": { "sweet-cookie": "dist/cli.js" } }, "sha512-+ugAbvXMl/mzmRRpGeeK4ShjWDZVR4Ul5DouKnwjhaqdozAakDyHceyagkOxRG8DYbCaQhTsuaMUod2nA3EKWQ=="],
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.4", "", {}, "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA=="],
 

--- a/dist/capture.js
+++ b/dist/capture.js
@@ -5,14 +5,14 @@ import {
   captureSummary,
   main,
   runCapture
-} from "./index-4p20c2mx.js";
+} from "./index-r6jry3pq.js";
 import"./index-7fzc32gf.js";
 import"./index-f984hw45.js";
 import {
   adapterCapabilities,
   inspectClipEnvironment,
   renderDoctorReport
-} from "./index-210486vj.js";
+} from "./index-n5618f1n.js";
 import"./index-5vdj4pae.js";
 import"./index-hgve9rh2.js";
 import"./index-w2zc0vwa.js";

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -114,10 +114,10 @@ import {
 } from "./index-ekpwvbra.js";
 import {
   main
-} from "./index-4p20c2mx.js";
+} from "./index-r6jry3pq.js";
 import"./index-7fzc32gf.js";
 import"./index-f984hw45.js";
-import"./index-210486vj.js";
+import"./index-n5618f1n.js";
 import {
   findKbPackageRoot
 } from "./index-5vdj4pae.js";

--- a/dist/clip/cli.js
+++ b/dist/clip/cli.js
@@ -5,10 +5,10 @@ import {
   captureSucceeded,
   captureSummary,
   main
-} from "../index-4p20c2mx.js";
+} from "../index-r6jry3pq.js";
 import"../index-7fzc32gf.js";
 import"../index-f984hw45.js";
-import"../index-210486vj.js";
+import"../index-n5618f1n.js";
 import"../index-5vdj4pae.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";

--- a/dist/clip/doctor.js
+++ b/dist/clip/doctor.js
@@ -9,7 +9,7 @@ import {
   renderAdapterCapabilities,
   renderDoctorReport,
   runDiagnosticCommand
-} from "../index-210486vj.js";
+} from "../index-n5618f1n.js";
 import"../index-5vdj4pae.js";
 import"../index-hgve9rh2.js";
 import"../index-w2zc0vwa.js";

--- a/dist/index-n5618f1n.js
+++ b/dist/index-n5618f1n.js
@@ -23,7 +23,7 @@ var homebrewSqliteLibraryPaths = [
 var dependencyVersions = {
   defuddle: "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.4",
+  "@steipete/sweet-cookie": "0.4.3",
   "@tobilu/qmd": expectedQmdVersion
 };
 var dependencyNames = [

--- a/dist/index-r6jry3pq.js
+++ b/dist/index-r6jry3pq.js
@@ -18,7 +18,7 @@ import {
   inspectClipEnvironment,
   renderAdapterCapabilities,
   renderDoctorReport
-} from "./index-210486vj.js";
+} from "./index-n5618f1n.js";
 import {
   acquireBrowser,
   acquireCookieHttp,

--- a/docs/design.md
+++ b/docs/design.md
@@ -603,7 +603,7 @@ embedding index. QMD is loaded only by index and search commands, so
 deterministic graph and metadata commands do not initialize its native runtime
 or model.
 
-[Defuddle](https://github.com/kepano/defuddle) performs article extraction. [agent-browser](https://github.com/vercel-labs/agent-browser) provides optional rendered acquisition. The pinned [Sweet Cookie safety fork](https://github.com/hraness/sweet-cookie) supports explicit browser-cookie import while retaining host-only scope and rejecting partitioned or container-scoped state that the capture lanes cannot replay faithfully.
+[Defuddle](https://github.com/kepano/defuddle) performs article extraction. [agent-browser](https://github.com/vercel-labs/agent-browser) provides optional rendered acquisition. The pinned [Sweet Cookie 0.4.3](https://github.com/steipete/sweet-cookie/releases/tag/v0.4.3) supports explicit browser-cookie import while retaining host-only scope and rejecting partitioned or container-scoped state that the capture lanes cannot replay faithfully.
 
 [yt-dlp](https://github.com/yt-dlp/yt-dlp) and [FFmpeg](https://ffmpeg.org) remain optional because only full audio or video localization needs them. `kb doctor` reports what is installed without probing cookie stores, and `kb adapters` reports the installed platform claims. A missing optional capability narrows the available route; it does not change the storage or graph model.
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,7 +1,7 @@
 # Publish KB
 
 The canonical artifact contract starts at `0.19.4`; that first attempt stopped
-with a retained partial draft. The prepared `0.19.5` candidate is not installable
+with a retained partial draft. The prepared `0.19.6` candidate is not installable
 until its immutable release completes. Each successful release contains
 one checked package archive, its packing receipt, a source/run manifest,
 checksums, and signed GitHub provenance. npm is an optional mirror of those
@@ -139,7 +139,7 @@ gh workflow run npm-stage.yml --ref main -f publish_to_npm=true
 ```
 
 The default candidate is current main's package version. To mirror an earlier
-canonical release while GitHub is ahead, add `-f release_tag=v0.19.5`. The input
+canonical release while GitHub is ahead, add `-f release_tag=v0.19.6`. The input
 must be one exact stable tag no newer than current main's version; its source
 must be an ancestor of the workflow commit, and its version must still be newer
 than npm `latest`. Neither a Git branch with a matching name nor an unqualified

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hraness/kb",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
   "license": "MIT",
   "contentPolicy": {
@@ -402,7 +402,7 @@
   },
   "dependencies": {
     "@hraness/oh": "github:hraness/oh#v0.2.0",
-    "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
+    "@steipete/sweet-cookie": "0.4.3",
     "@tobilu/qmd": "git+https://github.com/hraness/qmd.git#aa993dceb3ef8cfb71d470554ca437570f5a2b3c",
     "agent-browser": "0.32.3",
     "defuddle": "0.19.1",

--- a/portfolio-inventory.json
+++ b/portfolio-inventory.json
@@ -8,7 +8,7 @@
       "name": "@hraness/kb",
       "path": ".",
       "visibility": "public",
-      "version": "0.19.5"
+      "version": "0.19.6"
     }
   ],
   "dependencies": [
@@ -18,13 +18,6 @@
       "specifier": "github:hraness/oh#v0.2.0",
       "to": "@hraness/oh",
       "sourceRepository": "hraness/oh"
-    },
-    {
-      "from": "@hraness/kb",
-      "scope": "runtime",
-      "specifier": "github:hraness/sweet-cookie#v0.4.4",
-      "to": "@steipete/sweet-cookie",
-      "sourceRepository": "hraness/sweet-cookie"
     },
     {
       "from": "@hraness/kb",

--- a/scripts/kb-skill-contract.test.ts
+++ b/scripts/kb-skill-contract.test.ts
@@ -191,7 +191,7 @@ test("the shipped skill resources preserve routing and companion contracts", asy
     "references/url-platforms.md",
     "templates/companion-skill.template.md",
   ]);
-  expect(manifest.version).toBe("0.19.5");
+  expect(manifest.version).toBe("0.19.6");
   expect(manifestFiles).toContain("skills/kb");
   expect(publicSourceFiles).toContain("src/repository-memory.ts");
   expect(Object.keys(manifest.exports as Record<string, unknown>).toSorted()).toEqual([

--- a/scripts/kb-skill-contract.ts
+++ b/scripts/kb-skill-contract.ts
@@ -418,8 +418,8 @@ export function validateKbSkillContractResources(
       errors.push(`SKILL.md must link ${link}`);
     }
   }
-  if (!resources.skill.includes("bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz")) {
-    errors.push("SKILL.md must retain the immutable 0.19.5 GitHub runtime pin");
+  if (!resources.skill.includes("bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz")) {
+    errors.push("SKILL.md must retain the immutable 0.19.6 GitHub runtime pin");
   }
   for (const [name, contents, headings] of [
     ["customize.md", resources.customize, CUSTOMIZE_HEADINGS],

--- a/scripts/npm-release-workflow.test.ts
+++ b/scripts/npm-release-workflow.test.ts
@@ -383,7 +383,7 @@ describe("npm release workflows", () => {
       readonly version?: unknown;
     };
     expect(manifest).toEqual(expect.objectContaining({
-      version: "0.19.5",
+      version: "0.19.6",
       description: "A knowledge base for coding agents, built from Markdown, backlinks, semantic search, and Git context.",
       keywords: [
         "knowledge-base",

--- a/skills/kb/SKILL.md
+++ b/skills/kb/SKILL.md
@@ -55,7 +55,7 @@ missing:
 ```sh
 command -v kb >/dev/null 2>&1 || {
   command -v bun >/dev/null 2>&1 || exit 1
-  bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.5/hraness-kb-0.19.5.tgz
+  bun add --global --ignore-scripts https://github.com/hraness/kb/releases/download/v0.19.6/hraness-kb-0.19.6.tgz
 }
 kb --help
 ```

--- a/src/clip/cookies.test.ts
+++ b/src/clip/cookies.test.ts
@@ -19,7 +19,7 @@ const target = new URL("https://sub.example.com/account/page");
 const future = 4_102_444_800;
 
 describe("strict browser-like cookie filtering", () => {
-  test("patched Chromium provider treats an empty top-level site as unpartitioned", async () => {
+  test("pinned Chromium provider treats an empty top-level site as unpartitioned", async () => {
     const profile = mkdtempSync(join(tmpdir(), "hraness-kb-sweet-cookie-chromium-test-"));
     const cookieDatabase = join(profile, "Cookies");
     const database = new Database(cookieDatabase);
@@ -97,7 +97,7 @@ describe("strict browser-like cookie filtering", () => {
     }
   });
 
-  test("patched browser provider preserves host scope and excludes partitioned Firefox state", async () => {
+  test("pinned browser provider preserves host scope and excludes partitioned Firefox state", async () => {
     const profile = mkdtempSync(join(tmpdir(), "hraness-kb-sweet-cookie-test-"));
     const database = new Database(join(profile, "cookies.sqlite"));
     try {

--- a/src/clip/cookies.ts
+++ b/src/clip/cookies.ts
@@ -478,7 +478,7 @@ export function filterCookieProviderResult(value: unknown, target: URL): CookieP
   }
   // Browser databases distinguish host-only, Domain, partitioned, and container
   // cookies. A provider that drops that provenance cannot be replayed safely.
-  // Require the hostOnly field retained by the pinned provider fork; this also
+  // Require the hostOnly field retained by the pinned provider; this also
   // makes an install with an incompatible provider fail closed.
   const provenancePreserving = value.cookies.filter((cookie) =>
     isRecord(cookie) && typeof cookie.hostOnly === "boolean");

--- a/src/clip/doctor.test.ts
+++ b/src/clip/doctor.test.ts
@@ -35,7 +35,7 @@ describe("clip doctor", () => {
         dependencies: {
           defuddle: "^0.19.1",
           "agent-browser": "0.32.3",
-          "@steipete/sweet-cookie": "github:hraness/sweet-cookie#v0.4.4",
+          "@steipete/sweet-cookie": "0.4.3",
           "@tobilu/qmd": "2.5.3",
         },
       })],
@@ -43,7 +43,7 @@ describe("clip doctor", () => {
       [join(consumerRoot, "node_modules", "agent-browser", "package.json"), packageManifest("agent-browser", "0.32.3")],
       [
         join(consumerRoot, "node_modules", "@steipete", "sweet-cookie", "package.json"),
-        packageManifest("@steipete/sweet-cookie", "0.4.4"),
+        packageManifest("@steipete/sweet-cookie", "0.4.3"),
       ],
       [join(qmdRoot, "package.json"), packageManifest("@tobilu/qmd", "2.5.3")],
       [join(qmdRoot, "node_modules", "sqlite-vec", "package.json"), packageManifest("sqlite-vec", "0.1.9")],
@@ -138,13 +138,13 @@ describe("clip doctor", () => {
     });
     expect(report.dependencies.find(({ name }) => name === "@steipete/sweet-cookie")).toEqual({
       name: "@steipete/sweet-cookie",
-      expectedVersion: "0.4.4",
-      declaredVersion: "github:hraness/sweet-cookie#v0.4.4",
-      installedVersion: "0.4.4",
+      expectedVersion: "0.4.3",
+      declaredVersion: "0.4.3",
+      installedVersion: "0.4.3",
       status: "ready",
     });
     expect(renderDoctorReport(report)).toContain(
-      "@steipete/sweet-cookie: ready (declared github:hraness/sweet-cookie#v0.4.4; installed 0.4.4; expected 0.4.4)",
+      "@steipete/sweet-cookie: ready (declared 0.4.3; installed 0.4.3; expected 0.4.3)",
     );
     expect(report.search.keywordOnly).toEqual({ status: "ready", modelRequired: false });
     expect(report.search.semanticPrerequisites).toMatchObject({

--- a/src/clip/doctor.ts
+++ b/src/clip/doctor.ts
@@ -142,7 +142,7 @@ type JsonRecord = Readonly<Record<string, unknown>>;
 const dependencyVersions = {
   "defuddle": "0.19.1",
   "agent-browser": "0.32.3",
-  "@steipete/sweet-cookie": "0.4.4",
+  "@steipete/sweet-cookie": "0.4.3",
   "@tobilu/qmd": expectedQmdVersion,
 } as const satisfies Readonly<Record<DependencyReport["name"], string>>;
 const dependencyNames: readonly DependencyReport["name"][] = [


### PR DESCRIPTION
KB still installs a Hraness Sweet Cookie fork even though the scope/isolation and explicit Chromium Keychain fixes have shipped upstream. This prepares KB 0.19.6 with the exact upstream `@steipete/sweet-cookie@0.4.3` registry package, updates the doctor and installation references, and retains the strict cookie boundary and installed-provider regressions.

Upstream integrations: steipete/sweet-cookie#49 and steipete/sweet-cookie#51. The published archive was checked against its registry integrity and compared with the fork's safety behavior. QMD retains its existing immutable compatibility pin.

Validation:

- Full `bun run check`: 1,311 tests passed, plus 13 architecture checks; package, workflow, type, and Rust tool checks passed.
- Clean Bun/npm consumer installs with lifecycle scripts disabled; frozen repository installation passed.
- Generated `dist/` and `bun.lock` remained byte-identical through the full gate.
- Focused cookie-provider checks against the published upstream bytes: 17 passed. Synthetic fixtures only; no real browser or Keychain access.
- Independent source, dependency, and generated-output review.
