### PR TITLE
docs(site): expose verified Wordcell 0.20.0 installation

### DIFF
--- a/site/published-release.json
+++ b/site/published-release.json
@@ -1,4 +1,4 @@
 {
-  "version": null,
-  "verificationRun": null
+  "version": "0.20.0",
+  "verificationRun": "https://github.com/hraness/wordcell/actions/runs/34546777521"
 }


### PR DESCRIPTION
Wordcell’s homepage still shows the first-release preparation state even though 0.20.0 is published. Set its publication datum to 0.20.0 and the successful read-only recovery run so the homepage and documentation expose the verified archive and pinned Agent Skill installation commands.

The recovery verifies the original canonical archive, identical npm contents, installation, signatures and provenance. Its run is verification evidence; the original release run and immutable published bytes remain unchanged.

Validation: public canonical download and installed archive smoke; successful admission recovery 34546777521; required repository and site gates, including rendered production HTTP smoke.
