### PR TITLE
Apply shared Lantern material to the Wordcell site

### DIFF
--- a/site/BRIEF.md
+++ b/site/BRIEF.md
@@ -10,10 +10,13 @@ examples, current verified installation coordinates, and product boundaries.
 
 ## OWN-WORLD
 
-The shared editorial preset owns marketing display typography, spacing,
-controls, header treatment, and the fine-grained field with unfilled rectangular
-seams. Wordcell keeps its existing brand mark and fixed command-transcript
-contrast. The pinned Paper theme remains the underlying site theme.
+The shared editorial preset owns display typography, spacing and controls.
+Lantern adds quiet opaque reading planes, subtle seams, luminous header edges,
+and warm open-disclosure states over the pinned Paper palette. Its richer square
+wall belongs only behind the hero and its proof frame. Wordcell keeps its existing brand mark and fixed command-transcript
+contrast.
+The material arrives through a separate immutable snapshot; it adds no fonts,
+images or runtime package dependency.
 
 ## STORY
 
@@ -39,7 +42,26 @@ separate marketing snapshot carries its own immutable source and file hashes.
 ## FINISH
 
 Check actual desktop and phone layouts in both themes, including command
-readability, navigation fit, focus, section anchors, and the absence of filled
-grid patches. Keep README synchronization, published-release validation, and
+readability, navigation fit, focus, section anchors, and the canonical square wall without any texture on the product mark. Keep README synchronization, published-release validation, and
 stylesheet delivery checks. The integration owner runs final repository and
 production gates; this brief records requirements, not their completion.
+
+
+## MATERIAL ADOPTION
+
+`app/layout.tsx` supplies the document material context. `app/page.tsx` opts the
+header and proof into shared chrome/pane roles and wraps only the hero in the
+wall. `app/globals.css` imports `vendor/hraness-lantern/lantern-material.css`
+after the existing snapshots, bridges the old header paint, preserves the hero
+gutter, and binds existing reading surfaces and open questions to material
+colors. On phone widths the wrapping header stays in document flow so its variable
+height cannot cover section headings reached through navigation links. Desktop
+chrome remains sticky. The existing theme check calls the canonical offline snapshot checker.
+Docs/README typography, content, links and release facts remain
+unchanged, as do package versions and the pinned kit/UI peer graph.
+
+After the released snapshot is installed, run the existing site theme check,
+source/home/style tests, and focused lint before the integration owner runs the
+required final gates. Native review must cover desktop and phone, both palettes,
+header blur and opaque fallback, readable proof, open questions and keyboard
+focus; earlier System-only dark captures do not establish light coverage.

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -5,6 +5,7 @@
 
 @import "../vendor/paper-theme/paper-theme.css";
 @import "../vendor/hraness-marketing/product-marketing-preset.css";
+@import "../vendor/hraness-lantern/lantern-material.css";
 
 :root {
   --inverse-background: #14202a;
@@ -200,7 +201,7 @@ a:focus-visible {
   html { scroll-behavior: auto; }
 }
 
-::selection { background: var(--hraness-site-accent); color: var(--hraness-site-accent-ink); }
+::selection { background: var(--hraness-material-warm-plane); color: var(--hraness-material-ink); }
 a { text-underline-offset: 0.2em; }
 
 /* Wordcell document pages render README Markdown. */
@@ -231,4 +232,36 @@ a { text-underline-offset: 0.2em; }
 .wordcell-marketing-hero .hraness-marketing-proof-frame {
   --hraness-marketing-inverse: var(--inverse-background);
   --hraness-marketing-inverse-ink: var(--wordcell-code-foreground);
+}
+
+/* The existing grammar owns layout and controls. Lantern supplies only material
+   paint; these bridges keep old compiled peers and their focus rules intact. */
+[data-hraness-material="lantern"] .hraness-marketing-header.hraness-material-chrome {
+  -webkit-backdrop-filter: var(--hraness-material-chrome-blur, none);
+  backdrop-filter: var(--hraness-material-chrome-blur, none);
+  background: var(--hraness-material-chrome-paint, var(--hraness-material-plane));
+  border-block-end-color: var(--hraness-material-seam);
+}
+@media (max-width: 48rem) {
+  /* Wrapped navigation has a variable height; keep anchor headings unobscured. */
+  [data-hraness-material="lantern"] .hraness-marketing-header.hraness-material-chrome {
+    position: static;
+  }
+}
+[data-hraness-marketing-preset="editorial"] .hraness-material-wall > .hraness-marketing-hero {
+  padding-inline: var(--hraness-marketing-gutter);
+}
+[data-hraness-material="lantern"] .hraness-marketing-proof-frame.hraness-material-pane {
+  --hraness-marketing-line: var(--hraness-material-seam);
+  --hraness-marketing-surface: var(--hraness-material-plane);
+  box-shadow: var(--hraness-material-lift);
+}
+[data-hraness-material="lantern"] .hraness-marketing-question[open] > summary {
+  background-color: var(--hraness-material-warm-plane);
+  color: var(--hraness-material-ink);
+}
+[data-hraness-material="lantern"] :is(.document-page pre, .install-command) {
+  background: var(--hraness-material-plane);
+  border-color: var(--hraness-material-seam);
+  color: var(--hraness-material-ink);
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" data-hraness-theme="paper">
+    <html lang="en" data-hraness-theme="paper" data-hraness-material="lantern">
       <body>{children}</body>
     </html>
   );

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -143,6 +143,7 @@ export default function Home() {
       />
       <a className="skip-link" href="#main">Skip to content</a>
       <MarketingSiteHeader
+        className="hraness-material-chrome"
         action={{ href: "#install", label: "Install Wordcell" }}
         brand={<><BrandMark />Wordcell</>}
         brandLabel="Wordcell home"
@@ -151,7 +152,7 @@ export default function Home() {
 
       <main id="main" tabIndex={-1}>
         <MarketingPage>
-          <div className="hraness-marketing-field">
+          <div className="hraness-material-wall">
           <ProductHero
             align="start"
             actions={[
@@ -163,6 +164,7 @@ export default function Home() {
             eyebrow=""
             frame={(
               <MarketingProofFrame
+                className="hraness-material-pane"
                 caption="Example commands: record a constraint, inspect repository context, and recover its backlinks and history."
                 credit="From the README"
                 title="Keep one decision available to the next session"

--- a/site/scripts/check-paper-theme.mjs
+++ b/site/scripts/check-paper-theme.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { checkMarketingSnapshot } from "../vendor/hraness-marketing/check.mjs";
+import { checkLanternMaterialSnapshot } from "../vendor/hraness-lantern/check.mjs";
 
 // Offline integrity only: upgrades use the reviewed source's snapshot installer.
 const directories = ["vendor/paper-theme"];
@@ -26,3 +27,5 @@ for (const relative of directories) {
 console.log("Paper theme snapshots verified.");
 await checkMarketingSnapshot();
 console.log("Marketing snapshot verified.");
+await checkLanternMaterialSnapshot();
+console.log("Lantern material snapshot verified.");

--- a/site/tests/home.test.tsx
+++ b/site/tests/home.test.tsx
@@ -32,10 +32,10 @@ test("scopes the editorial preset to the homepage header and real command exampl
   const html = renderToStaticMarkup(<Home />);
   const elements: string[] = [];
   new HTMLRewriter()
-    .on('[data-hraness-marketing-preset="editorial"] .hraness-marketing-header', {
+    .on('[data-hraness-marketing-preset="editorial"] .hraness-marketing-header.hraness-material-chrome', {
       element() { elements.push("header"); },
     })
-    .on('[data-hraness-marketing-preset="editorial"] #main .hraness-marketing-field .hraness-marketing-proof-frame', {
+    .on('[data-hraness-marketing-preset="editorial"] #main .hraness-material-wall .hraness-marketing-proof-frame.hraness-material-pane', {
       element() { elements.push("proof"); },
     })
     .transform(html);

--- a/site/tests/source.test.ts
+++ b/site/tests/source.test.ts
@@ -93,3 +93,14 @@ test("publication metadata fails closed on malformed or partially verified relea
     expect(() => parsePublishedRelease(value)).toThrow();
   }
 });
+
+
+test("loads the immutable material after Paper and editorial styling", async () => {
+  const [css, layout, checker] = await Promise.all([read("app/globals.css"), read("app/layout.tsx"), read("scripts/check-paper-theme.mjs")]);
+  const materialImport = '@import "../vendor/hraness-lantern/lantern-material.css";';
+  expect(css).toContain(materialImport);
+  expect(css.indexOf(materialImport)).toBeGreaterThan(css.indexOf('product-marketing-preset.css";'));
+  expect(layout).toContain('data-hraness-material="lantern"');
+  expect(checker).toContain('import { checkLanternMaterialSnapshot } from "../vendor/hraness-lantern/check.mjs"');
+  expect(checker).toContain("await checkLanternMaterialSnapshot();");
+});

--- a/site/tests/ui-styles.test.tsx
+++ b/site/tests/ui-styles.test.tsx
@@ -80,3 +80,52 @@ describe("shared Ask AI stylesheet delivery", () => {
     expect(globals).not.toContain(".hraness-ask-ai-about-this__");
   });
 });
+
+
+test("delivers material chrome and reduced-transparency fallback through the existing CSS compiler", async () => {
+  const { root } = await compiled;
+  const header = new Map<string, string>();
+  let reducedTransparency = false;
+  let forcedPlane = false;
+  root.walkRules(rule => {
+    if (rule.selector === '[data-hraness-material="lantern"] .hraness-marketing-header.hraness-material-chrome') {
+      rule.walkDecls(declaration => { header.set(declaration.prop, declaration.value.replaceAll(/\s/gu, "")); });
+    }
+    const parent = rule.parent;
+    if (parent?.type === "atrule" && parent.name === "media") {
+      if (parent.params.includes("prefers-reduced-transparency") && rule.selector.includes("hraness-material-chrome")) {
+        rule.walkDecls("--hraness-material-chrome-blur", declaration => { if (declaration.value === "none") reducedTransparency = true; });
+      }
+      if (parent.params.includes("forced-colors") && rule.selector === '[data-hraness-material="lantern"]') {
+        rule.walkDecls("--hraness-material-plane", declaration => { if (declaration.value === "Canvas") forcedPlane = true; });
+      }
+    }
+  });
+  expect(header.get("backdrop-filter")).toBe("var(--hraness-material-chrome-blur,none)");
+  expect(header.get("-webkit-backdrop-filter")).toBe("var(--hraness-material-chrome-blur,none)");
+  expect(header.get("background")).toBe("var(--hraness-material-chrome-paint,var(--hraness-material-plane))");
+  expect(reducedTransparency).toBe(true);
+  expect(forcedPlane).toBe(true);
+});
+
+test("keeps wrapped phone navigation in flow while preserving desktop sticky chrome", async () => {
+  const { root } = await compiled;
+  let desktopSticky = false;
+  const phoneOverrides: Rule[] = [];
+  root.walkRules(rule => {
+    if (rule.selector === ".hraness-marketing-header") {
+      rule.walkDecls("position", declaration => { if (declaration.value === "sticky") desktopSticky = true; });
+    }
+    if (rule.selector === '[data-hraness-material="lantern"] .hraness-marketing-header.hraness-material-chrome') {
+      rule.walkDecls("position", declaration => { if (declaration.value === "static") phoneOverrides.push(rule); });
+    }
+  });
+  expect(desktopSticky).toBe(true);
+  expect(phoneOverrides).toHaveLength(1);
+  const parent = phoneOverrides[0]!.parent;
+  expect(parent?.type).toBe("atrule");
+  if (parent?.type !== "atrule") throw new Error("Phone chrome override must be scoped by a media query");
+  expect(parent.name).toBe("media");
+  expect(parent.params.replaceAll(/\s/gu, "")).toBe("(max-width:48rem)");
+  expect(phoneOverrides[0]!.nodes.filter(node => node.type === "decl").map(node => [node.prop, node.value])).toEqual([["position", "static"]]);
+});

--- a/site/vendor/hraness-lantern/LICENSE
+++ b/site/vendor/hraness-lantern/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hraness/design-kit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/site/vendor/hraness-lantern/check.d.mts
+++ b/site/vendor/hraness-lantern/check.d.mts
@@ -1,0 +1,26 @@
+/** Finite, asset-free portable presentation contract. */
+export const lanternSnapshotPaths: Readonly<{
+  "lantern-material.css": "src/lantern-material.css";
+  "check.mjs": "scripts/check-lantern-material-snapshot.mjs";
+  "check.d.mts": "scripts/check-lantern-material-snapshot.d.mts";
+  LICENSE: "LICENSE";
+}>;
+export type LanternSnapshotArtifact = keyof typeof lanternSnapshotPaths;
+export const lanternSnapshotFileLimits: Readonly<Record<LanternSnapshotArtifact, number>>;
+export interface LanternMaterialSnapshot {
+  readonly schemaVersion: 1;
+  readonly contractVersion: 1;
+  readonly source: {
+    readonly repository: "https://github.com/hraness/design-kit";
+    readonly commit: string;
+    readonly export: "@hraness/design-kit/lantern-material.css";
+  };
+  readonly files: Readonly<Record<LanternSnapshotArtifact, {
+    readonly path: string;
+    readonly sha256: string;
+  }>>;
+}
+export function createLanternMaterialSnapshot(commit: string, files: Readonly<Record<LanternSnapshotArtifact, Uint8Array>>): LanternMaterialSnapshot;
+export function parseLanternMaterialSnapshot(value: unknown): LanternMaterialSnapshot;
+/** Offline byte/provenance consistency check. This does not authenticate a GitHub release. */
+export function checkLanternMaterialSnapshot(directory?: string): Promise<LanternMaterialSnapshot>;

--- a/site/vendor/hraness-lantern/check.mjs
+++ b/site/vendor/hraness-lantern/check.mjs
@@ -1,0 +1,126 @@
+import { log } from "node:console";
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, open, readdir, realpath } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { TextDecoder } from "node:util";
+
+// This finite, asset-free inventory is owned by the checker, never the manifest.
+export const lanternSnapshotPaths = Object.freeze({
+  "lantern-material.css": "src/lantern-material.css",
+  "check.mjs": "scripts/check-lantern-material-snapshot.mjs",
+  "check.d.mts": "scripts/check-lantern-material-snapshot.d.mts",
+  LICENSE: "LICENSE",
+});
+export const lanternSnapshotFileLimits = Object.freeze({
+  "lantern-material.css": 256 * 1024,
+  "check.mjs": 128 * 1024,
+  "check.d.mts": 64 * 1024,
+  LICENSE: 64 * 1024,
+});
+const names = Object.keys(lanternSnapshotPaths);
+const repository = "https://github.com/hraness/design-kit";
+const exportedCss = "@hraness/design-kit/lantern-material.css";
+const checkerDirectory = dirname(fileURLToPath(import.meta.url));
+const record = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const keysEqual = (value, keys) => record(value) && Object.keys(value).sort().join("\n") === [...keys].sort().join("\n");
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const commitPattern = /^[a-f0-9]{40}$/u;
+const hashPattern = /^[a-f0-9]{64}$/u;
+
+export function createLanternMaterialSnapshot(commit, files) {
+  if (typeof commit !== "string" || !commitPattern.test(commit)) throw new Error("Snapshot source must be a full lowercase Git commit.");
+  if (!keysEqual(files, names)) throw new Error("Snapshot has missing or unowned source files.");
+  for (const name of names) {
+    if (!(files[name] instanceof Uint8Array) || files[name].byteLength === 0 || files[name].byteLength > lanternSnapshotFileLimits[name]) {
+      throw new Error(`Invalid ${name} source bytes.`);
+    }
+  }
+  return {
+    schemaVersion: 1,
+    contractVersion: 1,
+    source: { repository, commit, export: exportedCss },
+    files: Object.fromEntries(names.map((name) => [name, { path: lanternSnapshotPaths[name], sha256: sha256(files[name]) }])),
+  };
+}
+
+export function parseLanternMaterialSnapshot(value) {
+  if (!keysEqual(value, ["schemaVersion", "contractVersion", "source", "files"])
+    || value.schemaVersion !== 1 || value.contractVersion !== 1
+    || !keysEqual(value.source, ["repository", "commit", "export"])
+    || value.source.repository !== repository || value.source.export !== exportedCss
+    || typeof value.source.commit !== "string" || !commitPattern.test(value.source.commit)
+    || !keysEqual(value.files, names)) throw new Error("Invalid Lantern material snapshot provenance.");
+  for (const name of names) {
+    const receipt = value.files[name];
+    if (!keysEqual(receipt, ["path", "sha256"]) || receipt.path !== lanternSnapshotPaths[name]
+      || typeof receipt.sha256 !== "string" || !hashPattern.test(receipt.sha256)) throw new Error(`Invalid ${name} provenance.`);
+  }
+  return value;
+}
+
+function sameIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function physicalFile(path, maximum) {
+  const before = await lstat(path);
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1 || before.size === 0 || before.size > maximum) {
+    throw new Error("Snapshot files must be bounded physical files with one link.");
+  }
+  const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = await file.stat();
+    if (!sameIdentity(before, opened) || !opened.isFile() || opened.nlink !== 1 || opened.size !== before.size) {
+      throw new Error("Snapshot file changed while opening.");
+    }
+    // Read only the admitted length plus one sentinel byte. A concurrent
+    // append must fail without allocating or reading the growing file to EOF.
+    const bytes = Buffer.alloc(before.size + 1);
+    let length = 0;
+    while (length < bytes.length) {
+      const { bytesRead } = await file.read(bytes, length, bytes.length - length, length);
+      if (bytesRead === 0) break;
+      length += bytesRead;
+    }
+    const after = await file.stat();
+    const current = await lstat(path);
+    if (length !== before.size || !sameIdentity(before, current) || current.isSymbolicLink()
+      || current.nlink !== 1 || after.nlink !== 1 || after.size !== before.size
+      || after.mtimeMs !== opened.mtimeMs || after.ctimeMs !== opened.ctimeMs) throw new Error("Snapshot file changed while reading.");
+    return bytes.subarray(0, length);
+  } finally {
+    await file.close();
+  }
+}
+
+export async function checkLanternMaterialSnapshot(root = checkerDirectory) {
+  root = resolve(root);
+  const directory = await lstat(root);
+  if (!directory.isDirectory() || directory.isSymbolicLink()) throw new Error("Snapshot requires a physical directory.");
+  const entries = await readdir(root, { withFileTypes: true });
+  if (entries.map((entry) => entry.name).sort().join("\n") !== [...names, "provenance.json"].sort().join("\n")) {
+    throw new Error("Snapshot has missing or unowned files.");
+  }
+  if (entries.some((entry) => !entry.isFile() || entry.isSymbolicLink())) throw new Error("Snapshot requires only physical files.");
+  const provenanceBytes = await physicalFile(join(root, "provenance.json"), 16 * 1024);
+  const manifest = parseLanternMaterialSnapshot(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(provenanceBytes)));
+  for (const name of names) {
+    const bytes = await physicalFile(join(root, name), lanternSnapshotFileLimits[name]);
+    if (sha256(bytes) !== manifest.files[name].sha256) throw new Error(`${name} differs from its immutable snapshot.`);
+  }
+  if (!provenanceBytes.equals(await physicalFile(join(root, "provenance.json"), 16 * 1024))) throw new Error("Snapshot provenance changed while checking.");
+  const after = await lstat(root);
+  if (!sameIdentity(directory, after) || !after.isDirectory() || after.isSymbolicLink()
+    || (await readdir(root)).sort().join("\n") !== [...names, "provenance.json"].sort().join("\n")) throw new Error("Snapshot directory changed while checking.");
+  return manifest;
+}
+
+if (process.argv[1] !== undefined && await realpath(process.argv[1]).catch(() => undefined) === fileURLToPath(import.meta.url)) {
+  if (process.argv.length > 3) throw new Error("Usage: node check.mjs [SNAPSHOT_DIRECTORY]");
+  const manifest = await checkLanternMaterialSnapshot(process.argv[2] === undefined ? checkerDirectory : resolve(process.argv[2]));
+  log(`Lantern material snapshot verified at ${manifest.source.commit}.`);
+}

--- a/site/vendor/hraness-lantern/lantern-material.css
+++ b/site/vendor/hraness-lantern/lantern-material.css
@@ -1,0 +1,162 @@
+/* Lantern is an opt-in material, independent of palette and typography.
+ * All paint is deterministic CSS. No texture is placed over meaningful content. */
+@layer base {
+  [data-hraness-material="lantern"] {
+    --hraness-material-module: 4rem;
+    --hraness-material-warm: #d49a54;
+    --hraness-material-cool: #8d9fc5;
+    --hraness-material-plane: var(--surface, var(--ui-background, Canvas));
+    --hraness-material-ink: var(--foreground, var(--ui-foreground, CanvasText));
+    --hraness-material-muted: var(--muted, var(--ui-muted-foreground, CanvasText));
+    --hraness-material-seam: color-mix(in oklch, var(--hraness-material-ink) 16%, var(--hraness-material-plane));
+    --hraness-material-edge: color-mix(in oklch, white 28%, transparent);
+    --hraness-material-shade: color-mix(in oklch, black 14%, transparent);
+    --hraness-material-warm-plane: color-mix(in oklch, var(--hraness-material-warm) 12%, var(--hraness-material-plane));
+    --hraness-material-inset: inset 0 1px 3px color-mix(in oklch, black 9%, transparent);
+    --hraness-material-lift: inset 0 1px 0 var(--hraness-material-edge), 0 2px 4px color-mix(in oklch, black 7%, transparent), 0 12px 32px color-mix(in oklch, black 5%, transparent);
+    --hraness-material-focus: var(--focus, var(--ui-ring, Highlight));
+    --hraness-material-duration: 160ms;
+  }
+}
+
+@layer components.hraness-design-kit.legacy {
+  /* A quiet, opaque reading plane. The seam belongs to the surface perimeter. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-pane) {
+    background-color: var(--hraness-material-plane);
+    border: 1px solid var(--hraness-material-seam);
+    border-radius: var(--radius-lg, 0.75rem);
+    color: var(--hraness-material-ink);
+    min-inline-size: 0;
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-pane[data-depth="raised"]) {
+    box-shadow: var(--hraness-material-lift);
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-pane[data-depth="inset"]) {
+    background-color: color-mix(in oklch, var(--background, Canvas) 70%, var(--hraness-material-plane));
+    box-shadow: var(--hraness-material-inset);
+  }
+
+  /* A translucent enclosure, only where content actually passes behind it.
+   * Resolve these tokens on the chrome itself for nested palette islands. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-chrome) {
+    --hraness-material-chrome-paint: var(--surface, var(--ui-background, Canvas));
+    --hraness-material-chrome-blur: none;
+    background-color: var(--hraness-material-chrome-paint);
+    border-block-end: 1px solid var(--hraness-material-seam);
+    box-shadow: inset 0 1px 0 var(--hraness-material-edge), 0 4px 12px color-mix(in oklch, black 4%, transparent);
+  }
+  /* Bind the compiled TopBar's public paint seam at its own surface boundary. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-chrome.hraness-design-top-bar[data-surface="glass"]) {
+    --hraness-design-top-bar-background: var(--hraness-material-chrome-paint);
+    --hraness-design-top-bar-backdrop: var(--hraness-material-chrome-blur);
+  }
+  @supports (-webkit-backdrop-filter: blur(1px)) {
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-chrome) {
+      --hraness-material-chrome-paint: color-mix(in oklch, var(--surface, var(--ui-background, Canvas)) 90%, transparent);
+      --hraness-material-chrome-blur: blur(20px) saturate(1.1);
+      -webkit-backdrop-filter: var(--hraness-material-chrome-blur);
+    }
+  }
+  @supports (backdrop-filter: blur(1px)) {
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-chrome) {
+      --hraness-material-chrome-paint: color-mix(in oklch, var(--surface, var(--ui-background, Canvas)) 90%, transparent);
+      --hraness-material-chrome-blur: blur(20px) saturate(1.1);
+      backdrop-filter: var(--hraness-material-chrome-blur);
+    }
+  }
+
+  /* Glazing is a background material, with one square module and a warm band
+   * of transmitted light. Its edges suggest a rounded enclosure without
+   * distorting the document, blurring text, or masking brand artwork. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-wall) {
+    background-color: var(--background, var(--ui-background, Canvas));
+    background-image:
+      repeating-linear-gradient(90deg, transparent 0, transparent calc(var(--hraness-material-module) - 2px), color-mix(in oklch, var(--hraness-material-ink) 9%, transparent) calc(var(--hraness-material-module) - 2px), color-mix(in oklch, white 16%, transparent) calc(var(--hraness-material-module) - 1px), transparent var(--hraness-material-module)),
+      repeating-linear-gradient(0deg, transparent 0, transparent calc(var(--hraness-material-module) - 2px), color-mix(in oklch, var(--hraness-material-ink) 9%, transparent) calc(var(--hraness-material-module) - 2px), color-mix(in oklch, white 16%, transparent) calc(var(--hraness-material-module) - 1px), transparent var(--hraness-material-module)),
+      radial-gradient(ellipse at 60% 110%, color-mix(in oklch, var(--hraness-material-warm) 32%, transparent), transparent 62%),
+      linear-gradient(110deg, color-mix(in oklch, var(--hraness-material-cool) 22%, transparent), transparent 28%, color-mix(in oklch, white 8%, transparent) 48%, transparent 70%, color-mix(in oklch, var(--hraness-material-cool) 16%, transparent));
+    background-position: center top;
+    color: var(--hraness-material-ink);
+  }
+
+  /* Plain HTML control adapters. Compiled UI primitives use the public
+   * lanternControlStyles recipes through their documented controlXstyle seam.
+   * Edge paint uses background images, leaving focus shadows and outlines alone. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-control) {
+    background-image: linear-gradient(to bottom, var(--hraness-material-edge), transparent 2px);
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-input) {
+    background-image: linear-gradient(to bottom, var(--hraness-material-shade), transparent 4px);
+    caret-color: var(--hraness-material-focus);
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-choice[aria-pressed="true"], .hraness-material-choice[aria-selected="true"], .hraness-material-choice[data-selected]) {
+    background-color: var(--hraness-material-warm-plane);
+    color: var(--hraness-material-ink);
+    background-image: linear-gradient(to top, var(--hraness-material-warm), var(--hraness-material-warm) 2px, transparent 2px);
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-control:disabled, .hraness-material-control[aria-disabled="true"], .hraness-material-control[data-disabled], .hraness-material-input:disabled) {
+    background-image: none;
+  }
+
+  /* A collection is a readable sequence, never a requirement to fill a grid.
+   * Products own grouping, columns and the meaning of each row. */
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-rows) {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-rows > * + *) {
+    border-block-start: 1px solid var(--hraness-material-seam);
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-disclosure > summary) {
+    cursor: pointer;
+    min-block-size: 2.75rem;
+    padding-block: 0.75rem;
+  }
+  :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-disclosure > summary:focus-visible) {
+    outline: 2px solid var(--hraness-material-focus);
+    outline-offset: 3px;
+  }
+  [data-hraness-material="lantern"] ::selection {
+    background-color: var(--hraness-material-warm-plane);
+    color: var(--hraness-material-ink);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-hraness-material="lantern"] { --hraness-material-duration: 0ms; }
+  }
+  @media (prefers-reduced-transparency: reduce) {
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-chrome) {
+      --hraness-material-chrome-paint: var(--surface, var(--ui-background, Canvas));
+      --hraness-material-chrome-blur: none;
+    }
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-wall) { background-image: none; }
+  }
+  @media (forced-colors: active) {
+    [data-hraness-material="lantern"] {
+      --hraness-material-plane: Canvas;
+      --hraness-material-ink: CanvasText;
+      --hraness-material-muted: CanvasText;
+      --hraness-material-seam: CanvasText;
+      --hraness-material-focus: Highlight;
+      --hraness-material-warm-plane: Canvas;
+      --hraness-material-warm: Highlight;
+      --hraness-material-edge: transparent;
+      --hraness-material-inset: none;
+      --hraness-material-lift: none;
+    }
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-wall, .hraness-material-chrome, .hraness-material-pane) {
+      --hraness-material-chrome-paint: Canvas;
+      --hraness-material-chrome-blur: none;
+      background-color: Canvas;
+      background-image: none;
+      box-shadow: none;
+    }
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-control, .hraness-material-input, .hraness-material-choice) { background-image: none; }
+    :where([data-hraness-material="lantern"], [data-hraness-material="lantern"] *):is(.hraness-material-choice[aria-pressed="true"], .hraness-material-choice[aria-selected="true"], .hraness-material-choice[data-selected]) {
+      background-color: Highlight;
+      color: HighlightText;
+      background-image: none;
+    }
+  }
+}

--- a/site/vendor/hraness-lantern/provenance.json
+++ b/site/vendor/hraness-lantern/provenance.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "contractVersion": 1,
+  "source": {
+    "repository": "https://github.com/hraness/design-kit",
+    "commit": "eccb0341d8d0ba960a0f02248cf59888062afb0a",
+    "export": "@hraness/design-kit/lantern-material.css"
+  },
+  "files": {
+    "lantern-material.css": {
+      "path": "src/lantern-material.css",
+      "sha256": "484db814a12cfc54f1f13b580e16c1d1931ca780d8f1932ff0d4828494fe71fe"
+    },
+    "check.mjs": {
+      "path": "scripts/check-lantern-material-snapshot.mjs",
+      "sha256": "b3136bef0a28000c34b3dcc8ee1b890c29b0d0c26fec6895913e20532ff894ba"
+    },
+    "check.d.mts": {
+      "path": "scripts/check-lantern-material-snapshot.d.mts",
+      "sha256": "2f11fe7e67e6904fd097bcb227d2286df4215b32800f7aca7e44d0e881641db2"
+    },
+    "LICENSE": {
+      "path": "LICENSE",
+      "sha256": "763eaf6783097cac7303f10321b33ffc6a88c35845ba1e592b6a750e4568c5e0"
+    }
+  }
+}


### PR DESCRIPTION
Apply the shared Lantern material to the Wordcell homepage with a luminous hero background, blurred desktop header, opaque reading frame and warm disclosure states. The wrapped phone header now stays in document flow so anchor headings remain unobscured. Existing package versions, release facts, transcript and documentation styling remain intact.

Validation: the full root and site gates passed after the phone repair. Four actual built browser profiles (desktop/phone × light/dark) passed, including Ask AI alignment, disclosure focus, reduced transparency, forced colors, strict anchor clearance, documentation isolation and owned browser/server cleanup. Independent source and native-contract review passed. The five-file snapshot is bound to design-kit eccb0341, released unchanged in immutable v0.7.0.
